### PR TITLE
typo in reading/modules

### DIFF
--- a/reading/modules.livemd
+++ b/reading/modules.livemd
@@ -422,7 +422,7 @@ together.
 
 ## Default Arguments
 
-You can provide default arguments to functions using the `//` syntax after the parameter
+You can provide default arguments to functions using the `\\` syntax after the parameter
  and then the default value.
 
 ```elixir


### PR DESCRIPTION
'\\' should have been used instead of '//' for default arguments