### PR TITLE
Update structs.livemd

### DIFF
--- a/reading/structs.livemd
+++ b/reading/structs.livemd
@@ -161,7 +161,7 @@ You can define functions as usual.
 
 * Define a new struct `Hero`.
 
-* A `Hero` will have a `:hero_name`, `:catchphrase`, and `secret_identity`
+* A `Hero` will have a `:name`, `:catchphrase`, and `secret_identity`
 
 * create a `reveal/1` function which takes in an instance of a hero and returns
 
@@ -194,13 +194,13 @@ classDiagram
 
 ```
 
-Use the `Hero.introduce/1` function on `spider_man`.
+Use the `Hero.introduce/2` function on `spider_man`.
 
 ```elixir
 
 ```
 
-Use the `Hero.reveal/2` function on `spider_man`.
+Use the `Hero.reveal/1` function on `spider_man`.
 
 ```elixir
 


### PR DESCRIPTION
Changed Hero struct key :hero_name to :name because on line 173 `"#{greeting} I am #{hero.name}"` this is to be outputed. So accessing hero.name raises key not found error.
And interchanged the arity of introduced and reveal function. On line 166 * create a `reveal/1` function which takes in an instance of a hero and returns 
and line 170 * create an `introduce/2` function which takes in an instance of a hero and a greeting
arity of functions to be defined are different.