### PR TITLE
Typo in enum.livemd

### DIFF
--- a/reading/enum.livemd
+++ b/reading/enum.livemd
@@ -166,7 +166,7 @@ In the Elixir cell below, convert `[1, 2]` into `[{:int, 1}, {:int, 2}]`
 ```
 
 Bonus: In the Elixir cell below, instead of using the generic `:number` atom key, convert
-`[1, 2]` into `[{:one, 1}, {:two, 3}]`
+`[1, 2]` into `[{:one, 1}, {:two, 2}]`
 
 ```elixir
 


### PR DESCRIPTION
Replaced 3 with 2 as the guide tells to convert [1,2] not [1,3]