### PR TITLE
Update enum.livemd

### DIFF
--- a/reading/enum.livemd
+++ b/reading/enum.livemd
@@ -389,25 +389,25 @@ Enum.reduce(%{key: "value"}, fn tuple, _accumulator -> tuple end)
 
 ### Your Turn
 
-In the Elixir cell below, use `Enum.reduce/1` to sum all of the **values** in a map.
-So `%{key1: 1, key2: 10}` should become 10.
+In the Elixir cell below, use `Enum.reduce/2` to sum all of the **values** in a map.
+So `%{key1: 1, key2: 10}` should become 11.
 
 ```elixir
 map = %{key1: 1, key2: 10}
 ```
 
-In the Elixir cell below, use `Enum.reduce/1` to sum all of the **keys** and **values** in a map.
+In the Elixir cell below, use `Enum.reduce/2` to sum all of the **keys** and **values** in a map.
 So `%{1 => 15, 10 => 12}` should become `38` `(1 + 15 + 10 + 12)`  .
 
 ```elixir
 map = %{key1: 1, key2: 10}
 ```
 
-Use `Enum.reduce/1` to sum all of the values in a keyword list.
-so `%{add: 20, add: 5}` should become `25`.
+Use `Enum.reduce/2` to sum all of the values in a keyword list.
+so `[add: 20, add: 5]` should become `25`.
 
 ```elixir
-keyword_list = %{add: 20, add: 5}
+keyword_list = [add: 20, add: 5]
 ```
 
 ## Further Reading.


### PR DESCRIPTION
 Enum.reduce arity typos. On line 393 sum of the map values would be 11. On line 406 we sum up values in key word list not a map. So changed map into key word list.