### PR TITLE
fix typo in startup mad libs exercise

### DIFF
--- a/exercises/mad_libs.livemd
+++ b/exercises/mad_libs.livemd
@@ -38,7 +38,7 @@ secret_sauce = nil
 
 madlib = nil
 
-Utils.feedback(:startup_madlib_answers, [
+Utils.feedback(:startup_madlib, [
   madlib,
   name_of_company,
   a_defined_offering,

--- a/utils/lib/feedback.ex
+++ b/utils/lib/feedback.ex
@@ -197,7 +197,7 @@ defmodule Utils.Feedback do
            "each variable should be bound to a non-empty string"
 
     assert madlib ==
-             "My company, #{name_of_company} is developing #{a_defined_offering} to help #{a_defined_audience} #{solve_a_problem} with #{secret_sauce}."
+             "My company, #{name_of_company}, is developing #{a_defined_offering} to help #{a_defined_audience} #{solve_a_problem} with #{secret_sauce}."
   end
 
   feedback :nature_show_madlib do


### PR DESCRIPTION
corrected name of the feedback macro to be implemented. Also, if the user binds one of the variables to a non-binary type, such as number or nil, the livebook evaluator throws an error before the assertion macro is implemented. (See picture below).
<img width="974" alt="Screenshot 2022-05-23 at 7 40 25 PM" src="https://user-images.githubusercontent.com/85004512/169840646-5997e299-0d2d-4589-8578-aa462bb99b34.png">

This happens because using non-binary values in string concatenation throws an error in Elixir (note that this does not happen in the next cell where string interpolation is used instead.)

I tried moving the `Utils.feedback` code before the `madlib`, but then `madlib` is undefined and that again causes an error. Perhaps there's a way to catch any errors thrown by the evaluator and show them alongside the feedback from the `feedback` macro?