### PR TITLE
Fix typo in Guess the Number exercise

### DIFF
--- a/exercises/guessing_games.livemd
+++ b/exercises/guessing_games.livemd
@@ -46,7 +46,7 @@ In the Elixir cell below create a number guessing game.
 * Bind a variable `answer` to the actual answer as an integer.
 * If `guess` equals `answer` bind `correct` to `"Correct!"`
 * If `guess` is less than `answer` bind `correct` to `"Too low!"`
-* If `guess` is greater than `answer` bind `correct` to `"Too low!"`
+* If `guess` is greater than `answer` bind `correct` to `"Too high!"`
 
 Run your code with an equal, smaller, and larger `guess` than the `answer` to ensure your
 code passes all tests.


### PR DESCRIPTION
This is a small typo fix. The exercise should have thee different choices Correct, Too low, and Too high.