### PR TITLE
Fix list order not guaranteed

### DIFF
--- a/utils/lib/feedback.ex
+++ b/utils/lib/feedback.ex
@@ -326,10 +326,10 @@ defmodule Utils.Feedback do
     assert is_map(family_tree), "Ensure `family_tree` is a map."
     assert %{name: "Arthur"} = family_tree, "Ensure `family_tree` starts with Arthur."
 
-    assert %{name: "Arthur", parents: _list} = family_tree,
+    assert %{name: "Arthur", parents: parents } = family_tree,
            "Ensure Arthur in `family_tree` has a list of parents."
+    assert length(parents) == 2, "Ensure both parents are included."
 
-    assert family_tree == Utils.Solutions.family_tree()
   end
 
   feedback :naming_numbers do

--- a/utils/lib/solutions.ex
+++ b/utils/lib/solutions.ex
@@ -147,7 +147,9 @@ defmodule Utils.Solutions do
     bridget = %{
       name: "Bridget",
       status: :grand_parent,
-      age: 70
+      age: 70,
+      parents: []
+
     }
 
     ygraine = %{


### PR DESCRIPTION
Pattern matching fails when the student's solution parent's list is [ygraine, uther] instead of [uther, ygraine] since list order can not be guaranteed for a student's solution. 