### PR TITLE
fix typo that leads to error message on correct solution submission

### DIFF
--- a/exercises/shopping_list.livemd
+++ b/exercises/shopping_list.livemd
@@ -60,5 +60,5 @@ items from the `shopping_cart`
 ```elixir
 shopping_cart = []
 
-Utils.feedback(:shopping_cart_with_quantities, shopping_cart)
+Utils.feedback(:shopping_list_with_quantities, shopping_cart)
 ```


### PR DESCRIPTION
In `Utils.Feedback`  shopping_list_with_quanties is passed to `feedback/2`, not shopping_cart_with_quantities. This fixes the following error message:

"Something went wrong, feedback does not exist for shopping_cart_with_quantities. Please speak to your teacher and/or reset the exercise."
