### PR TITLE
Fix compilation warnings and add check task to GitHub Actions

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Install dependencies
       working-directory: ./utils
       run: mix deps.get
+    - name: Check compilation warnings
+      working-directory: ./utils
+      run: mix compile --warnings-as-errors
     - name: Run tests
       working-directory: ./utils
       run: mix test

--- a/utils/lib/solutions.ex
+++ b/utils/lib/solutions.ex
@@ -1003,16 +1003,13 @@ defmodule Utils.Solutions do
   defmodule Pascal do
     def row(1), do: [1]
     def row(2), do: [1, 1]
+    def row(n), do: generate_row(row(n - 1), [1])
 
     def generate_row(previous_row, acc \\ []) do
       case previous_row do
         [first, second | tail] -> generate_row([second | tail], [first + second | acc])
         _ -> [1 | acc]
       end
-    end
-
-    def row(n) do
-      generate_row(row(n - 1), [1])
     end
 
     def of(n) do
@@ -1031,7 +1028,7 @@ defmodule Utils.Solutions do
 
       remaining
       |> Enum.reduce([first_sublist], fn
-        item, [[h | t] | _] = acc -> [t ++ [item] | acc]
+        item, [[_h | t] | _] = acc -> [t ++ [item] | acc]
       end)
       |> Enum.reverse()
     end
@@ -1286,7 +1283,7 @@ defmodule Utils.Solutions do
       %__MODULE__{amount: amount, currency: currency}
     end
 
-    def convert(%__MODULE__{amount: amount, currency: from_currency} = money, to_currency) do
+    def convert(%__MODULE__{amount: amount, currency: from_currency} = _money, to_currency) do
       cad_amount =
         case from_currency do
           :CAD -> amount


### PR DESCRIPTION
This resolved issues encountered when running `mix compile --warnings-as-error`. We also added a task for this command in GitHub Actions.

```
$ cd utils
$ mix clean
$ mix compile --warnings-as-error
Compiling 14 files (.ex)
warning: clauses with the same name and arity (number of arguments) should be grouped together, "def row/1" was previously defined (lib/solutions.ex:1004)
  lib/solutions.ex:1014

warning: variable "h" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/solutions.ex:1034: Utils.Solutions.Sublist.sublists/2

warning: variable "money" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/solutions.ex:1289: Utils.Solutions.Money.convert/2

Generated utils app
```