### PR TITLE
Resolve warnings on undefined Kino.VegaLite's functions

### DIFF
--- a/reading/command_line.livemd
+++ b/reading/command_line.livemd
@@ -4,7 +4,8 @@
 Mix.install([
   {:kino, github: "livebook-dev/kino", override: true},
   {:kino_lab, "~> 0.1.0-dev", github: "jonatanklosko/kino_lab"},
-  {:vega_lite, "~> 0.1.3"},
+  {:vega_lite, "~> 0.1.4"},
+  {:kino_vega_lite, "~> 0.1.1"},
   {:benchee, "~> 0.1"},
   {:ecto, "~> 3.7"},
   {:math, "~> 0.7.0"},
@@ -20,7 +21,7 @@ Mix.install([
 
 ## Overview
 
-We use the command line to interact with our computer through a text interface rather than through a 
+We use the command line to interact with our computer through a text interface rather than through a
 Graphical User Interface (GUI).
 
 Many programs only run through the command line. Generally, we call these **Command-Line Applications**, **CLI Applications** (for Command Line Interface), or just **CLIs**.

--- a/utils/mix.exs
+++ b/utils/mix.exs
@@ -21,8 +21,9 @@ defmodule Utils.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:kino, github: "livebook-dev/kino"},
-      {:vega_lite, "~> 0.1.3"},
+      {:kino, github: "livebook-dev/kino", override: true},
+      {:vega_lite, "~> 0.1.4"},
+      {:kino_vega_lite, "~> 0.1.1"},
       {:benchee, "~> 0.1"},
       {:ecto, "~> 3.7"},
       {:math, "~> 0.7.0"},

--- a/utils/mix.lock
+++ b/utils/mix.lock
@@ -8,9 +8,11 @@
   "faker": {:hex, :faker, "0.17.0", "671019d0652f63aefd8723b72167ecdb284baf7d47ad3a82a15e9b8a6df5d1fa", [:mix], [], "hexpm", "a7d4ad84a93fd25c5f5303510753789fc2433ff241bf3b4144d3f6f291658a6a"},
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
   "jason": {:hex, :jason, "1.3.0", "fa6b82a934feb176263ad2df0dbd91bf633d4a46ebfdffea0c8ae82953714946", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "53fc1f51255390e0ec7e50f9cb41e751c260d065dcba2bf0d08dc51a4002c2ac"},
-  "kino": {:git, "https://github.com/livebook-dev/kino.git", "3611e2a6a5b2fc6e207beb585a441f3c53b6700a", []},
+  "kino": {:git, "https://github.com/livebook-dev/kino.git", "1662f638c51b156683abe3ba978d6cb9f737888b", []},
+  "kino_vega_lite": {:hex, :kino_vega_lite, "0.1.1", "29438b43a3fd3e0f1c8560ed9f943fe593b293e710fc091c63d65b272dd6255f", [:mix], [{:kino, "~> 0.6.1", [hex: :kino, repo: "hexpm", optional: false]}, {:table, "~> 0.1.0", [hex: :table, repo: "hexpm", optional: false]}, {:vega_lite, "~> 0.1.4", [hex: :vega_lite, repo: "hexpm", optional: false]}], "hexpm", "7058ffd10379b4b33a2bbca0b4a3bd6a124ef45136df01d3ccfd4f82ab368473"},
   "live_slide": {:git, "https://github.com/brooklinjazz/live_slide.git", "fd03f15b2f883679527e958df7388353df31a51a", []},
   "math": {:hex, :math, "0.7.0", "12af548c3892abf939a2e242216c3e7cbfb65b9b2fe0d872d05c6fb609f8127b", [:mix], [], "hexpm", "7987af97a0c6b58ad9db43eb5252a49fc1dfe1f6d98f17da9282e297f594ebc2"},
+  "table": {:hex, :table, "0.1.1", "e8d3c75bb14b8dac227e17d85a626e695d96c271569e94e4a2d15494a7cb0b49", [:mix], [], "hexpm", "6a73280b2f5ad70474594feeb8c034ad490b97dbd5adaeb678f71c250cbc928c"},
   "telemetry": {:hex, :telemetry, "1.0.0", "0f453a102cdf13d506b7c0ab158324c337c41f1cc7548f0bc0e130bbf0ae9452", [:rebar3], [], "hexpm", "73bc09fa59b4a0284efb4624335583c528e07ec9ae76aca96ea0673850aec57a"},
-  "vega_lite": {:hex, :vega_lite, "0.1.3", "38eeb47d66a881086d0e596b592e3aa75084115d00315c387716c131684f3513", [:mix], [], "hexpm", "ea6e8f951944144b15f26d0b33c255c2b1b553a65e3fffcd91784bfdc56ebb54"},
+  "vega_lite": {:hex, :vega_lite, "0.1.4", "97f3f59f1a8b65169aa7dd861b0e13d10fb73e18b1f8546b953c34a74cab33ef", [:mix], [{:table, "~> 0.1.0", [hex: :table, repo: "hexpm", optional: false]}], "hexpm", "b9d0ec3e978b9d1b1a37024e218391f9c1d5a90b783ed2ed988bf5a9b2fddefb"},
 }


### PR DESCRIPTION
This resolves the warnings below when Mix install the deps in Command
Line page.

```
warning: Kino.VegaLite.new/1 is undefined (module Kino.VegaLite is not
available or is yet to be defined

warning: Kino.VegaLite.push_many/2 is undefined (module Kino.VegaLite is
not available or is yet to be defined)
```

![image](https://user-images.githubusercontent.com/134518/172863668-0ffb42ec-7aad-4fa0-bfe3-d50d77e4edd4.png)

