### PR TITLE
Fix warnings when `mix test`

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -36,7 +36,7 @@ jobs:
       run: mix compile --warnings-as-errors
     - name: Run tests
       working-directory: ./utils
-      run: mix test
+      run: mix test --warnings-as-errors
 
   codespell:
     name: Check for spelling errors

--- a/utils/lib/feedback.ex
+++ b/utils/lib/feedback.ex
@@ -1129,7 +1129,7 @@ defmodule Utils.Feedback do
 
     assert today.hour == now.hour
     # Allowing 2 second adjustment for possible time delay
-    DateTime.diff(now, today) < 2
+    assert DateTime.diff(now, today) < 2
   end
 
   feedback :datetime_tomorrow do
@@ -1141,7 +1141,7 @@ defmodule Utils.Feedback do
     assert tomorrow.day == now.day + 1
     assert tomorrow.hour == now.hour
     # Allowing 2 second adjustment for possible time delay
-    DateTime.diff(DateTime.add(now, 60 * 60 * 24, :second), tomorrow) < 2
+    assert DateTime.diff(DateTime.add(now, 60 * 60 * 24, :second), tomorrow) < 2
   end
 
   feedback :datetime_compare do
@@ -1661,7 +1661,7 @@ defmodule Utils.Feedback do
 
     list = Enum.to_list(1..5)
 
-    assert custom_enum.reduce(list, 0, fn each, acc -> each end),
+    assert custom_enum.reduce(list, 0, fn each, _acc -> each end),
            "Ensure you implement the `reduce/3` function."
 
     assert custom_enum.reduce(list, 0, fn each, acc -> acc + each end) == 15
@@ -1963,7 +1963,7 @@ defmodule Utils.Feedback do
   end
 
   feedback :evolvable do
-    [evolvable, charmander, charmeleon, charizard] = get_answers
+    [evolvable, charmander, charmeleon, charizard] = get_answers()
 
     assert Keyword.get(evolvable.__info__(:functions), :evolve),
            "add the `evolve` function to the `Evolvable` protocol."


### PR DESCRIPTION
List of warnings:
- warning: use of operator < has no effect
- warning: variable "acc" is unused
- warning: variable "get_answers" does not exist and is being expanded to "get_answers()"

We also add the `--warnings-as-errors` option to `mix test` in GitHub
Actions.