### PR TITLE
fix typo in built-in modules section

### DIFF
--- a/reading/built-in_modules.livemd
+++ b/reading/built-in_modules.livemd
@@ -450,7 +450,7 @@ Utils.feedback(:map_values, values)
 
 ## The Keyword Module
 
-The [Keyword](https://hexdocs.pm/elixir/Keyword.html#functions) module contains functionality related to maps.
+The [Keyword](https://hexdocs.pm/elixir/Keyword.html#functions) module contains functionality related to keyword lists.
 
 Here are a few common functions to get you started.
 


### PR DESCRIPTION
This part of the lesson is about keyword lists.