### PR TITLE
Feedback not implemented for the corresponding reading exercise

### DIFF
--- a/utils/lib/feedback.ex
+++ b/utils/lib/feedback.ex
@@ -2390,6 +2390,12 @@ defmodule Utils.Feedback do
     assert call_with_20.(fn int -> int * 10 end) == 20 * 10
   end
 
+    
+  feedback :range_to_list do 
+    list = get_answers()
+    assert list == [3,6,9]
+  end
+
   feedback :created_project do
     path = get_answers()
 


### PR DESCRIPTION
Feedback not implemented for the corresponding reading exercise on ranges:

https://github.com/DockYard-Academy/beta_curriculum/blob/fbf67b6289624882ce29d17bc79067ffbb3a41cd/reading/ranges.livemd


### Your Turn

In the Elixir cell below, Use `Enum.to_list` enter a range from `3` to `9` with a step of `3`. 
Replace `nil` with your answer.

```elixir
answer = nil

Utils.test(:range_to_list, answer)
```