### PR TITLE
Fix html in fun-formulas page

### DIFF
--- a/exercises/fun_formulas.livemd
+++ b/exercises/fun_formulas.livemd
@@ -127,7 +127,7 @@ Given `c_square`, calculate `c`. Replace `nil` with your answer.
 
 <details>
 <summary>Hint</summary>
-check out `:math.sqrt`
+Check out <code>:math.sqrt/1</code>.
 </details>
 
 ```elixir


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/134518/174480946-10ceb5d7-990b-4f22-8936-f30e00f6f5b3.png)


After:
![image](https://user-images.githubusercontent.com/134518/174480923-d2e161f3-35a9-4496-8c4c-d72599d91ec9.png)
