### PR TITLE
Remove syntax error.

### DIFF
--- a/exercises/tally_votes.livemd
+++ b/exercises/tally_votes.livemd
@@ -59,7 +59,7 @@ VoterPower.tally([dogs: 10, dogs: 20, cats: 2])
 %{dogs: 30, cats: 2}
 ```
 
-You will also need to handle atoms within the list.
+You will also need to handle keyword list within the list.
 
 <!-- livebook:{"force_markdown":true} -->
 

--- a/exercises/tally_votes.livemd
+++ b/exercises/tally_votes.livemd
@@ -64,7 +64,7 @@ You will also need to handle atoms within the list.
 <!-- livebook:{"force_markdown":true} -->
 
 ```elixir
-VoterPower.tally([:dogs, :dogs, dogs: 2, :cats])
+VoterPower.tally([:dogs, :dogs, :cats, dogs: 2])
 %{dogs: 4, cats: 1}
 ```
 


### PR DESCRIPTION
Keyword lists must always come last in lists and maps.

