### PR TITLE
Remove trailing punctuation in header (MD026)

### DIFF
--- a/exercises/anagram_solver.livemd
+++ b/exercises/anagram_solver.livemd
@@ -56,7 +56,7 @@ defmodule AnagramSolver do
 end
 ```
 
-### Validate Your Solution.
+### Validate Your Solution
 
 To validate your solution, ensure the following matches the expected output above. The order of anagrams does not matter.
 

--- a/exercises/bomb_defusal.livemd
+++ b/exercises/bomb_defusal.livemd
@@ -63,7 +63,7 @@ Utils.feedback(:created_project, "bomb_defusal")
 
 Dialyzer, Credo, and ExDoc are optional for this project.
 
-## Create the Bomb GenServer.
+## Create the Bomb GenServer
 
 Create a `Bomb` `GenServer`. It should start as a minimal `GenServer` with no functionality.
 

--- a/exercises/candy_store.livemd
+++ b/exercises/candy_store.livemd
@@ -68,7 +68,7 @@ Create the following test cases for the following:
 - given a `:name`, `:cost`, and `:type` field it should create an Item struct.
 - The Item struct should enforce the `:name` and `:type` fields.
 
-## Create the CandyStore.search/2 function.
+## Create the CandyStore.search/2 function
 
 The `CandyStore.search/2` function should take a list of items, and the a search query to filter them by.
 For example,
@@ -93,7 +93,7 @@ Create a `CandyStore.search/2` function and the following test cases:
 
 Ensure all tests pass.
 
-## (Bonus) Search by price.
+## (Bonus) Search by price
 
 Add the following functionality and cases to allow users to search by price:
 - given a list of items, when searching by `:max_cost`, it should find items below the max cost.

--- a/exercises/factorial.livemd
+++ b/exercises/factorial.livemd
@@ -57,7 +57,7 @@ defmodule Factorial do
 end
 ```
 
-### Validate Your Solution.
+### Validate Your Solution
 
 To test your solution, ensure the following code does not crash with a **MatchError**.
 

--- a/exercises/games_rock_paper_scissors.livemd
+++ b/exercises/games_rock_paper_scissors.livemd
@@ -27,7 +27,7 @@ Using the command line, create a new project in the `projects` folder called `ga
 mix new games
 ```
 
-## Create a Rock Paper Scissors game.
+## Create a Rock Paper Scissors game
 
 You're going to create a rock paper scissors game where players will play against an AI which randomly chooses
 rock, paper, or scissors.

--- a/exercises/mazes.livemd
+++ b/exercises/mazes.livemd
@@ -166,7 +166,7 @@ path = nil
 Utils.feedback(:treasure_map, [treasure_map, path])
 ```
 
-### (Bonus) Update the treasure map.
+### (Bonus) Update the treasure map
 
 Use map update syntax `%{map | key => "new value"}` or `%{map | key: "new value"}` and update the `treasure_map`
 to show the `"gold"` has been `"taken"`.

--- a/exercises/mining_simulator.livemd
+++ b/exercises/mining_simulator.livemd
@@ -75,7 +75,7 @@ Dialyzer, Credo, and ExDoc are optional for this project.
 Configure the MineSupervisor to start in `application.ex`.
 The MineSupervisor should be able to dynamically supervise its child `Mine` workers.
 
-## Configure the ResourceStore.
+## Configure the ResourceStore
 
 Configure the `ResourceStore` to start in `application.ex`.
 The `ResourceStore` should be a `GenServer` or `Agent`, which starts with `200` gold in its state.

--- a/exercises/rock_paper_scissors_genserver.livemd
+++ b/exercises/rock_paper_scissors_genserver.livemd
@@ -19,7 +19,7 @@ Mix.install([
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
 [Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
 
-## Rock Paper Scissors Genserver.
+## Rock Paper Scissors Genserver
 
 So far we've created synchronous rock paper scissors where each player needs to enter their guess into the same function at the same time.
 

--- a/exercises/spoonacular_recipe_api.livemd
+++ b/exercises/spoonacular_recipe_api.livemd
@@ -27,11 +27,11 @@ Mix.install([
 
 Create a free Spoonacular to get your API key. You can view your API key in the [Spoonacular Console](https://spoonacular.com/food-api/console#Dashboard).
 
-### Browser Request.
+### Browser Request
 
 Use your API to visit the `https://api.spoonacular.com/recipes/complexSearch?apiKey=API_KEY` URL where API_KEY should be your API key from the console.
 
-### HTTPoison request.
+### HTTPoison request
 
 Use `HTTPoison` to retrieve the same JSON data from the `https://api.spoonacular.com/recipes/complexSearch?apiKey=API_KEY` URL you visited in the browser. Then use `Poison` to decode the JSON response into an Elixir data structure.
 

--- a/exercises/video_game_spawner.livemd
+++ b/exercises/video_game_spawner.livemd
@@ -58,7 +58,7 @@ Using the command line, create a new supervised project in the `projects` folder
 mix new spawner --sup
 ```
 
-## Create the Creature GenServer.
+## Create the Creature GenServer
 
 Create a `Creature` GenServer. It should start as a minimal GenServer with no additional functionality for now.
 

--- a/reading/command_line.livemd
+++ b/reading/command_line.livemd
@@ -318,7 +318,7 @@ You can read file contents with the following commands.
 * **macOS & GNU/Linux**: `cat`
 * **Windows**: `type`.
 
-### Your Turn.
+### Your Turn
 
 Create a new file `read_example.txt` with some text content.
 You can use `echo` on every operating system to create a file with some content. However,

--- a/reading/comprehensions.livemd
+++ b/reading/comprehensions.livemd
@@ -247,7 +247,7 @@ for a <- 1..45, rem(a, 5) === 0, rem(b, 5) === 0, b <- 1..5 do
 end
 ```
 
-### Your turn.
+### Your turn
 
 In the Elixir cell below, create a comprehension with a filter that generates every combination
 of 2 numbers up to 6 that equal 7.

--- a/reading/enum.livemd
+++ b/reading/enum.livemd
@@ -184,6 +184,7 @@ In the Elixir cell below, convert `[1, 2]` into `[{:int, 1}, {:int, 2}]`
 ```
 
 ### Your Turn (Bonus)
+
 Bonus: In the Elixir cell below, instead of using the generic `:int` atom key, convert
 `1..9` into `[{:one, 1}, {:two, 2}, ...and so on]`. You only need to handle numbers from `0` to `9`.
 
@@ -409,7 +410,7 @@ so `[add: 20, add: 5]` should become `25`.
 keyword_list = [add: 20, add: 5]
 ```
 
-## Further Reading.
+## Further Reading
 
 The Enum module has many more functions. You'll have the opportunity to encounter more
 as you need them to solve future challenges.

--- a/reading/exunit.livemd
+++ b/reading/exunit.livemd
@@ -733,7 +733,7 @@ $ mix test test/math_test.exs
 
 <!-- livebook:{"break_markdown":true} -->
 
-### Run tests by line number.
+### Run tests by line number
 
 We can execute a specific test or several tests under a `describe` block by providing the line number.
 

--- a/reading/iex.livemd
+++ b/reading/iex.livemd
@@ -89,7 +89,7 @@ Once we've started the `IEx` shell, you can close it by pressing
 CTRL
 </kbd>
 
-### Your Turn.
+### Your Turn
 
 First, define a variable in your current `IEx` shell.
 

--- a/reading/maps.livemd
+++ b/reading/maps.livemd
@@ -106,7 +106,7 @@ use a different tool called the [Map](https://hexdocs.pm/elixir/Map.html) module
 
 For now, it's enough to know that you can access values in an atom-key map using a few different methods.
 
-### Accessing Map Values.
+### Accessing Map Values
 
 You can retrieve values in a map using **map.key** notation like so. This only works for maps with
 atom keys.

--- a/reading/maps_mapsets_keyword_lists.livemd
+++ b/reading/maps_mapsets_keyword_lists.livemd
@@ -1,4 +1,4 @@
-# Maps, Mapsets, and Keyword Lists.
+# Maps, Mapsets, and Keyword Lists
 
 ```elixir
 Mix.install([

--- a/reading/mix.livemd
+++ b/reading/mix.livemd
@@ -385,7 +385,7 @@ in `mix.exs`. Notice that `mix.exs` includes comments on installing a dependency
   end
 ```
 
-### Your Turn.
+### Your Turn
 
 Add the [Faker](https://hex.pm/packages/faker) project to your `hello_world` application.
 `Faker` provides functions for generating fake data, often useful for randomized test data.

--- a/reading/persistence.livemd
+++ b/reading/persistence.livemd
@@ -198,7 +198,7 @@ be working on an email newsletter. Your sales team has entered a list of emails 
 If there's only a handful of emails, you might manually copy paste these into your program, but if there are thousands, you'll have to
 write some code to convert them into data that you can persist in your program.
 
-## DBMS (Database Management System).
+## DBMS (Database Management System)
 
 Generally speaking, we use a **Database** to store long-term information in a program. The Database is a separate layer in the program that
 handles the complexity of storing information.

--- a/reading/scripts.livemd
+++ b/reading/scripts.livemd
@@ -144,7 +144,7 @@ a number.
 Consider using module attributes, which are created at compile time and will not change.
 </details>
 
-## Loading Multiple Files.
+## Loading Multiple Files
 
 Generally, a script is a single `.exs` file used for some singular purpose. While it is possible to load other
 files with the [Code](https://hexdocs.pm/elixir/Code.html) module to split up functionality and create larger projects, it's


### PR DESCRIPTION
This PR resolves all warnings raised by markdownlint where the header
ended with punctuation except those with exclamation or question mark.

https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md026

Something similar to issue https://github.com/DockYard-Academy/beta_curriculum/issues/104