### PR TITLE
Remove multiple consecutive blank lines (MD012)

### DIFF
--- a/exercises/rock_paper_scissors_genserver.livemd
+++ b/exercises/rock_paper_scissors_genserver.livemd
@@ -123,7 +123,6 @@ Player.stats(player2_pid)
 %{wins: 0, ties: 0, loses: 1}
 ```
 
-
 In the Elixir cell below, create the `Game` and `Player` GenServer modules.
 
 ```elixir

--- a/reading/deprecated_binary.livemd
+++ b/reading/deprecated_binary.livemd
@@ -176,7 +176,6 @@ is called a **byte**.
 
 <!-- livebook:{"break_markdown":true} -->
 
-
 As we count from 1 to 9, we then add a 1 in the placeholder on the left, and restart at 0.
 You probably do this intuitively. This means we have placeholders for **ones**, **tens**, **hundreds**, etc.
 
@@ -188,7 +187,6 @@ Can you imagine if we had different symbols for every number?
 It would be impossible to remember.
 
 ## CodePoints
-
 
 ### How did we go from Integers to Strings?
 


### PR DESCRIPTION
This PR resolves all warnings raised by markdownlint where the we've
multiple consecutive blank lines.

See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md012.