### PR TITLE
Update erlang depedency version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.13.3-otp-24
-erlang 24.3
+erlang 24.34.2
 nodejs 17.4.0


### PR DESCRIPTION
Installing Erlang 24.3 may present [issues when installing on newer versions of Mac OS](https://github.com/asdf-vm/asdf-erlang/issues/248). 

But [this was fixed](https://github.com/asdf-vm/asdf-erlang/issues/248#issuecomment-1119916326) in newer Erlang versions.