### PR TITLE
Bump Erlang/Elixir versions for asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.13.3-otp-24
-erlang 24.34.2
+elixir 1.13.4-otp-25
+erlang 25.0.2
 nodejs 17.4.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Contact Brooklin (brooklin.myers@dockyard.com) or DM at [@BrooklinJMyers](https:
 
 ## QuickStart
 
-1. Install a compatible Elixir (1.13.3 or higher) and Erlang (24 or higher)
+1. Install a compatible Elixir (1.13.4 or higher) and Erlang (25 or higher)
    version. You may wish to use
    [asdf](https://asdf-vm.com/guide/getting-started.html#_1-install-dependencies).
 


### PR DESCRIPTION
Note that an incorrect Erlang version was updated from https://github.com/DockYard-Academy/beta_curriculum/pull/129/files