### PR TITLE
Remove random HiddenCell

### DIFF
--- a/exercises/mad_libs.livemd
+++ b/exercises/mad_libs.livemd
@@ -104,12 +104,6 @@ secret_sauce = nil
 madlib = nil
 ```
 
-<!-- livebook:{"attrs":{"source":"2 + 2"},"kind":"Elixir.Utils.SmartCell.HiddenCell","livebook_object":"smart_cell"} -->
-
-```elixir
-2 + 2
-```
-
 ## String Interpolation Madlib
 
 In the Elixir cell below, fill in `blank1`, `blank2`, and `blank3` with a word to replace the blanks in the sentence.


### PR DESCRIPTION
I found a strange `HiddenCell` in the middle of Mad Libs livebook.
Maybe used for testing purposes but forgotten to be cleaned since