### PR TITLE
Add kino_lab to utils project

### DIFF
--- a/utils/mix.exs
+++ b/utils/mix.exs
@@ -23,6 +23,7 @@ defmodule Utils.MixProject do
   defp deps do
     [
       {:kino, github: "livebook-dev/kino", override: true},
+      {:kino_lab, "~> 0.1.0-dev", github: "jonatanklosko/kino_lab"},
       {:vega_lite, "~> 0.1.4"},
       {:kino_vega_lite, "~> 0.1.1"},
       {:benchee, "~> 0.1"},


### PR DESCRIPTION
People using livebook desktop need all dependencies the projects uses to be in the `utils` project until we replace `utils` entirely.

This PR adds `kino_lab` to resolve `Kino.Youtube` not being available.