### PR TITLE
Add MacOS keybindings where needed

### DIFF
--- a/exercises/livebook_recovery.livemd
+++ b/exercises/livebook_recovery.livemd
@@ -33,7 +33,7 @@ Button on the sidebar.
 
 Edit the following Elixir cell to say `"hello <your_name>"` where `<your_name>` is your name.
 
-Then use <kbd>CTRL</kbd>+ <kbd>Z</kbd> to undo your edit.
+Then use <kbd>CTRL</kbd>+<kbd>Z</kbd> (Windows & Linux) or <kbd>CMD</kbd>+<kbd>Z</kbd> (MacOS) to undo your edit.
 
 ```elixir
 "Hello <yourname>"
@@ -42,7 +42,7 @@ Then use <kbd>CTRL</kbd>+ <kbd>Z</kbd> to undo your edit.
 Edit the following markdown cell to say `"hello <yourname>"` where `<yourname>` is your name.
 You can press the <i class="ri-pencil-line"></i> button to start editing.
 
-Then use <kbd>CTRL</kbd>+ <kbd>Z</kbd> to undo your edit.
+Then use <kbd>CTRL</kbd>+<kbd>Z</kbd> (Windows & Linux) or <kbd>CMD</kbd>+<kbd>Z</kbd> (MacOS)  to undo your edit.
 
 <!-- livebook:{"break_markdown":true} -->
 

--- a/reading/code_editors.livemd
+++ b/reading/code_editors.livemd
@@ -112,7 +112,7 @@ files for this course unless directed to.
 ## Quick Open
 
 For large projects, it quickly becomes tedious to search through files and folders.
-Instead, you can use the **Quick Open** Command with <kbd>Ctrl</kbd>+<kbd>P</kbd>. Here
+Instead, you can use the **Quick Open** Command with <kbd>Ctrl</kbd>+<kbd>P</kbd> (Windows & Linux) or <kbd>CMD</kbd>+<kbd>P</kbd> (MacOS). Here
 you can search for the name of a file and press <kbd>Enter</kbd> to view it in the editor.
 
 <!-- livebook:{"break_markdown":true} -->
@@ -132,7 +132,7 @@ when working at scale, and you'll want to be proficient with it.
 Visual Studio Code has many useful commands. In addition, many extensions add additional
 commands.
 
-Press <kbd>CTRL</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> to show all commands. You'll notice that it simply
+Press <kbd>CTRL</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> (Windows & Linux) or <kbd>CMD</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> (MacOS) to show all commands. You'll notice that it simply
 uses Quick Open with a `>` symbol. You could also open Quick Open and then press `>`.
 
 <!-- livebook:{"break_markdown":true} -->
@@ -187,7 +187,7 @@ For example, when running this curriculum using the integrated terminal that ter
 ## Search
 
 You can use the Search tab to find content in files. Alternatively you can quickly open the
-search with the <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>F</kbd> shortcut.
+search with the <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>F</kbd> (Windows & Linux) or <kbd>CMD</kbd>+<kbd>SHIFT</kbd>+<kbd>F</kbd> (MacOS) shortcut.
 
 Enter text into the search input and press <kbd>Enter</kbd> to search for some text.
 

--- a/reading/livebook.livemd
+++ b/reading/livebook.livemd
@@ -82,7 +82,7 @@ to see the Markdown content inside.
 Elixir cells contain Elixir code. Evaluate the cell to show the result.
 
 You can click on an Elixir cell to see the <i class="ri-play-circle-fill"></i> Evaluate button.
-Alternatively you can evaluate an Elixir cell by clicking on it the cell and pressing <kbd>CTRL</kbd>+<kbd>Enter</kbd>.
+Alternatively you can evaluate an Elixir cell by clicking on it the cell and pressing <kbd>CTRL</kbd>+<kbd>Enter</kbd> (Windows & Linux) or <kbd>CMD</kbd>+<kbd>Enter</kbd> (MacOS).
 
 Click on the Elixir cell below and then click <i class="ri-play-circle-fill"></i> Evaluate to see the result. You
 should see `10` because `5 + 5` equals `10`.
@@ -137,10 +137,9 @@ Re-evaluate the cell to see *Evaluated* change to **Evaluated**.
 
 ## Formatting
 
-You can format Elixir code using the <kbd>ALT</kbd>+<kbd>SHIFT</kbd>+<kbd>F</kbd> Keybinding.
+You can format Elixir code using the <kbd>ALT</kbd>+<kbd>SHIFT</kbd>+<kbd>F</kbd> (Windows & Linux) Keybinding or <kbd>SHIFT</kbd>+<kbd>OPTION</kbd>+<kbd>F</kbd> (MacOS).
 
-Try uncommenting the following code (Remove the `#` character) then press <kbd>ALT</kbd>+<kbd>SHIFT</kbd>+<kbd>F</kbd>
-to format the code.
+Try uncommenting the following code (Remove the `#` character) then press <kbd>ALT</kbd>+<kbd>SHIFT</kbd>+<kbd>F</kbd> (Windows & Linux) or <kbd>SHIFT</kbd>+<kbd>OPTION</kbd>+<kbd>F</kbd> (MacOS) to format the code.
 
 Notice that the `1 + 1` code moves to the left.
 


### PR DESCRIPTION
Addresses #65. Current livebook keybindings are windows &linux only. This PR updates relevant `.livemd` files to also mention MacOS keybindings.