### PR TITLE
Add missing quote in possible solution recommendation.

### DIFF
--- a/exercises/mad_libs.livemd
+++ b/exercises/mad_libs.livemd
@@ -119,7 +119,7 @@ In the Elixir cell below, fill in `blank1`, `blank2`, and `blank3` with a word t
 
 Then use string interpololation to interpolate these values into a single string bound to the `madlib` variable.
 
-<!-- livebook:{"attrs":{"assertions":"assert is_binary(blank1) and blank1 != \"\", \"blank1 should be a non-empty string\"\nassert is_binary(blank2) and blank2 != \"\", \"blank2 should be a non-empty string\"\nassert is_binary(blank3) and blank3 != \"\", \"blank3 should be a non-empty string\"\nassert madlib == \"A programmer is a #{blank1} that turns #{blank2} into #{blank3}.\"","code":"blank1 = nil\r\nblank2 = nil\r\nblank3 = nil\r\n\r\nmadlib = nil","solution":"blank1 = \"machine\"\nblank2 = \"coffee\"\nblank3 = \"code\n\nmadlib = \"A programmer is a #{blank1} that turns #{blank2} into #{blank3}.\""},"kind":"Elixir.TestedCell","livebook_object":"smart_cell"} -->
+<!-- livebook:{"attrs":{"assertions":"assert is_binary(blank1) and blank1 != \"\", \"blank1 should be a non-empty string\"\nassert is_binary(blank2) and blank2 != \"\", \"blank2 should be a non-empty string\"\nassert is_binary(blank3) and blank3 != \"\", \"blank3 should be a non-empty string\"\nassert madlib == \"A programmer is a #{blank1} that turns #{blank2} into #{blank3}.\"","code":"blank1 = nil\r\nblank2 = nil\r\nblank3 = nil\r\n\r\nmadlib = nil","solution":"blank1 = \"machine\"\nblank2 = \"coffee\"\nblank3 = \"code\"\n\nmadlib = \"A programmer is a #{blank1} that turns #{blank2} into #{blank3}.\""},"kind":"Elixir.TestedCell","livebook_object":"smart_cell"} -->
 
 ```elixir
 ExUnit.start(auto_run: false)


### PR DESCRIPTION
I think the possible solution in this block was missing an end quote for the string `code`.

This is what I saw on a fresh version of the workbook.

<img width="961" alt="Screen Shot 2022-09-07 at 9 06 33 PM" src="https://user-images.githubusercontent.com/52168/189011298-366b7946-5b2a-42a9-b928-21cb4130bba2.png">
