### PR TITLE
[Fixes #293] Updates `.tool-versions`.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,2 @@
-elixir 1.13.3-otp-24
+elixir 1.13.4-otp-25
 erlang 25.0.2
-nodejs 18.8.0


### PR DESCRIPTION
Fixes #293

* Removes the nodejs declaration. 
* Updates the elixir version to a newer bug fix and aligns its OTP level with the existing erlang version.
