### PR TITLE
[Fixes #334] Fixes the referred arity of File.rm to be `File.rm/1`.

### DIFF
--- a/reading/file.livemd
+++ b/reading/file.livemd
@@ -154,16 +154,16 @@ to return an error and halt execution.
 File.write!("non_existing_folder/test", "hello, world!")
 ```
 
-## File.rm/2
+## File.rm/1
 
-`rm` is short for **remove**. We use [File.rm/2](https://hexdocs.pm/elixir/File.html#rm/2) to delete existing files.
+`rm` is short for **remove**. We use [File.rm/1](https://hexdocs.pm/elixir/File.html#rm/1) to delete existing files.
 
 ```elixir
 File.write("data/temp", "Goodbye!")
 File.rm("data/temp")
 ```
 
-[File.rm/2](https://hexdocs.pm/elixir/File.html#rm/2) will return an error tuple `{:error, :enoent}` if the file does not exist. As usual, you can use the bang `!` version of the function to fail and halt execution.
+[File.rm/1](https://hexdocs.pm/elixir/File.html#rm/1) will return an error tuple `{:error, :enoent}` if the file does not exist. As usual, you can use the bang `!` version of the function to fail and halt execution.
 
 ```elixir
 File.rm("data/non_existing_file")
@@ -183,7 +183,7 @@ You can always use **Git** to recover committed project files, but the same isn'
 outside of this project. Proceed with caution!
 
 In the Elixir cell below, delete the written file `"data/delete_me"` using
-[File.rm/2](https://hexdocs.pm/elixir/File.html#rm/2). Check the `data` folder to make sure.
+[File.rm/1](https://hexdocs.pm/elixir/File.html#rm/1). Check the `data` folder to make sure.
 
 ```elixir
 File.write("data/delete_me", "")


### PR DESCRIPTION
Fixes #334 