### PR TITLE
Issue #367 - Clarify `git add .` directory.

### DIFF
--- a/exercises/anagram.livemd
+++ b/exercises/anagram.livemd
@@ -108,7 +108,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/anagram_solver.livemd
+++ b/exercises/anagram_solver.livemd
@@ -61,7 +61,7 @@ AnagramSolver.solve("cat")
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/arithmetic.livemd
+++ b/exercises/arithmetic.livemd
@@ -264,7 +264,7 @@ Seventy divided by (ten plus two).
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/battle_map.livemd
+++ b/exercises/battle_map.livemd
@@ -131,7 +131,7 @@ Modify the existing solution above to add your custom character.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/benchmarks.livemd
+++ b/exercises/benchmarks.livemd
@@ -110,7 +110,7 @@ Ensure that you test these operations with `1000` elements, `10_000` elements, a
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/binary_search.livemd
+++ b/exercises/binary_search.livemd
@@ -151,7 +151,7 @@ Binary.search(large_tuple, 9_987_000)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/bingo_winner.livemd
+++ b/exercises/bingo_winner.livemd
@@ -192,7 +192,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/bomb_defusal.livemd
+++ b/exercises/bomb_defusal.livemd
@@ -96,7 +96,7 @@ the application supervisor.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/boolean_operators.livemd
+++ b/exercises/boolean_operators.livemd
@@ -279,7 +279,7 @@ Utils.form(:boolean_fill_in_the_blank)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/bottles_of_soda.livemd
+++ b/exercises/bottles_of_soda.livemd
@@ -317,7 +317,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/caesar_cypher.livemd
+++ b/exercises/caesar_cypher.livemd
@@ -173,7 +173,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/candy_store.livemd
+++ b/exercises/candy_store.livemd
@@ -113,7 +113,7 @@ Then create the following test cases:
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/capstone_project_mock.livemd
+++ b/exercises/capstone_project_mock.livemd
@@ -47,7 +47,7 @@ Use [Trello](https://trello.com/) or some other Kanban application such as a [Gi
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/card_counting.livemd
+++ b/exercises/card_counting.livemd
@@ -181,7 +181,7 @@ Enter your solution below.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/character_generator.livemd
+++ b/exercises/character_generator.livemd
@@ -113,7 +113,7 @@ an instance of a `Character` struct i.e. `%Character{params}`.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/classified.livemd
+++ b/exercises/classified.livemd
@@ -64,7 +64,7 @@ Utils.feedback(:classified, Classified)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/concurrent_image_processing.livemd
+++ b/exercises/concurrent_image_processing.livemd
@@ -74,7 +74,7 @@ MultiImage.convert(["a.png", "b.png", "c.png", "d.png"]) == [
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/counting_votes.livemd
+++ b/exercises/counting_votes.livemd
@@ -111,7 +111,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/creature_spawner.livemd
+++ b/exercises/creature_spawner.livemd
@@ -77,7 +77,7 @@ an interval (i.e. 5 seconds)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/currency_conversion.livemd
+++ b/exercises/currency_conversion.livemd
@@ -98,7 +98,7 @@ This exercise is inspired by the Elixir [Money](https://github.com/elixirmoney/m
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/custom_enum_with_recursion.livemd
+++ b/exercises/custom_enum_with_recursion.livemd
@@ -72,7 +72,7 @@ Utils.feedback(:enum_recursion, CustomEnum)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/custom_enum_with_reduce.livemd
+++ b/exercises/custom_enum_with_reduce.livemd
@@ -187,7 +187,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/custom_rock_paper_scissors.livemd
+++ b/exercises/custom_rock_paper_scissors.livemd
@@ -103,7 +103,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/deprecated_cards.livemd
+++ b/exercises/deprecated_cards.livemd
@@ -89,7 +89,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/distributed_rock_paper_scissors.livemd
+++ b/exercises/distributed_rock_paper_scissors.livemd
@@ -807,7 +807,7 @@ the necessary changes to fix the bugs.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/dominoes.livemd
+++ b/exercises/dominoes.livemd
@@ -70,7 +70,7 @@ Use the <code>:rest_for_one</code> strategy for your supervisor.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/email_validation.livemd
+++ b/exercises/email_validation.livemd
@@ -68,7 +68,7 @@ exists and belongs to them.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/factorial.livemd
+++ b/exercises/factorial.livemd
@@ -68,7 +68,7 @@ To test your solution, ensure the following code does not crash with a **MatchEr
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/factory.livemd
+++ b/exercises/factory.livemd
@@ -20,7 +20,7 @@ In order to understand more about
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/family_tree.livemd
+++ b/exercises/family_tree.livemd
@@ -129,7 +129,7 @@ family_tree = %{}
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/fibonacci.livemd
+++ b/exercises/fibonacci.livemd
@@ -87,7 +87,7 @@ Benchee.run(
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/file_system_todo_app.livemd
+++ b/exercises/file_system_todo_app.livemd
@@ -73,7 +73,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/file_types.livemd
+++ b/exercises/file_types.livemd
@@ -43,7 +43,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/filter_values_by_type.livemd
+++ b/exercises/filter_values_by_type.livemd
@@ -120,7 +120,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/fizzbuzz.livemd
+++ b/exercises/fizzbuzz.livemd
@@ -58,7 +58,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/fun_formulas.livemd
+++ b/exercises/fun_formulas.livemd
@@ -154,7 +154,7 @@ Enter your solution below.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/games_rock_paper_scissors.livemd
+++ b/exercises/games_rock_paper_scissors.livemd
@@ -71,7 +71,7 @@ or keep a running tally in memory (using a process).
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/guessing_games.livemd
+++ b/exercises/guessing_games.livemd
@@ -124,7 +124,7 @@ Enter your solution below.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/habit_tracker.livemd
+++ b/exercises/habit_tracker.livemd
@@ -174,7 +174,7 @@ how it would affect calculating the total score and/or the total percentage of c
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/home_page.livemd
+++ b/exercises/home_page.livemd
@@ -64,7 +64,7 @@ Then you could the use the `<i>` tag and [Lineicons icons](https://lineicons.com
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/inventory_management.livemd
+++ b/exercises/inventory_management.livemd
@@ -62,7 +62,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/item_generator.livemd
+++ b/exercises/item_generator.livemd
@@ -150,7 +150,7 @@ items = nil
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/item_search.livemd
+++ b/exercises/item_search.livemd
@@ -72,7 +72,7 @@ Utils.feedback(:item_generator_search, Search)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/itinerary.livemd
+++ b/exercises/itinerary.livemd
@@ -61,7 +61,7 @@ Utils.feedback(:itinerary, Itinerary)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/journal.livemd
+++ b/exercises/journal.livemd
@@ -57,7 +57,7 @@ class Entry {
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/journal_cli.livemd
+++ b/exercises/journal_cli.livemd
@@ -280,7 +280,7 @@ You can use [IO.puts/2](https://hexdocs.pm/elixir/IO.html#puts/2) to print infor
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/kitchen_queue.livemd
+++ b/exercises/kitchen_queue.livemd
@@ -111,7 +111,7 @@ Test your solution by uncommenting and executing the code below.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/lucas_numbers.livemd
+++ b/exercises/lucas_numbers.livemd
@@ -66,7 +66,7 @@ Utils.feedback(:lucas_numbers, LucasNumbers)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/mad_libs.livemd
+++ b/exercises/mad_libs.livemd
@@ -70,7 +70,7 @@ Enter your solution below.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/math.livemd
+++ b/exercises/math.livemd
@@ -131,7 +131,7 @@ Utils.feedback(:math_module, Math)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/math_game.livemd
+++ b/exercises/math_game.livemd
@@ -40,7 +40,7 @@ Display the current player scores in the math game. You should be able to open t
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/mazes.livemd
+++ b/exercises/mazes.livemd
@@ -228,7 +228,7 @@ Utils.feedback(:update_treasure_map, [treasure_map, updated_map])
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/measurements.livemd
+++ b/exercises/measurements.livemd
@@ -120,7 +120,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/metric_conversion.livemd
+++ b/exercises/metric_conversion.livemd
@@ -56,7 +56,7 @@ Utils.feedback(:metric_measurements, Measurement)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/mining_simulator.livemd
+++ b/exercises/mining_simulator.livemd
@@ -101,7 +101,7 @@ The' Mine' should terminate without being restarted by the `MineSupervisor` when
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/mix_math.livemd
+++ b/exercises/mix_math.livemd
@@ -361,7 +361,7 @@ raise a [FunctionClauseError](https://hexdocs.pm/elixir/FunctionClauseError.html
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/naming_numbers.livemd
+++ b/exercises/naming_numbers.livemd
@@ -157,7 +157,7 @@ numbering_names = nil
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/number_wordle.livemd
+++ b/exercises/number_wordle.livemd
@@ -75,7 +75,7 @@ Utils.feedback(:number_wordle, NumberWordle)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/pascals_triangle.livemd
+++ b/exercises/pascals_triangle.livemd
@@ -124,7 +124,7 @@ Utils.feedback(:pascal, Pascal)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/personality_quiz_script.livemd
+++ b/exercises/personality_quiz_script.livemd
@@ -51,7 +51,7 @@ Once finished with the quiz, it should print out a result based on their answers
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/phone_number_parsing.livemd
+++ b/exercises/phone_number_parsing.livemd
@@ -66,7 +66,7 @@ Utils.feedback(:phone_number_parsing, PhoneNumber)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/phone_parsing.livemd
+++ b/exercises/phone_parsing.livemd
@@ -64,7 +64,7 @@ PhoneNumbers.get()
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/pokemon_api.livemd
+++ b/exercises/pokemon_api.livemd
@@ -68,7 +68,7 @@ Pokemon.from_response(response)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/pokemon_battle.livemd
+++ b/exercises/pokemon_battle.livemd
@@ -264,7 +264,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/pokemon_protocols.livemd
+++ b/exercises/pokemon_protocols.livemd
@@ -123,7 +123,7 @@ Utils.feedback(:evolvable, [Evolvable, Charmander, Charmeleon, Charizard])
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/pokemon_server.livemd
+++ b/exercises/pokemon_server.livemd
@@ -211,7 +211,7 @@ Modify your solution above to complete this bonus section.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/portfolio_auth_blog_page.livemd
+++ b/exercises/portfolio_auth_blog_page.livemd
@@ -34,7 +34,7 @@ Remember to use the `mix phx.gen.auth` command to generate the initial authentic
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/portfolio_blog_images.livemd
+++ b/exercises/portfolio_blog_images.livemd
@@ -52,7 +52,7 @@ Ensure you:
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/portfolio_blog_live_search.livemd
+++ b/exercises/portfolio_blog_live_search.livemd
@@ -39,7 +39,7 @@ Consider including the following test cases.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/portfolio_blog_page.livemd
+++ b/exercises/portfolio_blog_page.livemd
@@ -65,7 +65,7 @@ The navigation should include a link to the `"/"` route to view the home page, a
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/portfolio_blog_search.livemd
+++ b/exercises/portfolio_blog_search.livemd
@@ -82,7 +82,7 @@ Consider including the following test cases.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/portfolio_comments.livemd
+++ b/exercises/portfolio_comments.livemd
@@ -68,7 +68,7 @@ Ensure you:
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/portfolio_home_page.livemd
+++ b/exercises/portfolio_home_page.livemd
@@ -53,7 +53,7 @@ Try to match the document above as best you can, however you may exercise your c
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/portfolio_mock.livemd
+++ b/exercises/portfolio_mock.livemd
@@ -48,7 +48,7 @@ You might choose to include:
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/portfolio_tags.livemd
+++ b/exercises/portfolio_tags.livemd
@@ -56,7 +56,7 @@ Add a feature to the blog search form to search for blogs by tag.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/product_filters.livemd
+++ b/exercises/product_filters.livemd
@@ -93,7 +93,7 @@ ExUnit.run()
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/public_chat_api.livemd
+++ b/exercises/public_chat_api.livemd
@@ -37,7 +37,7 @@ HTTPoison.post("http://localhost:4000", "{\"body\": \"hello!\"}", [
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/rock_paper_scissors.livemd
+++ b/exercises/rock_paper_scissors.livemd
@@ -159,7 +159,7 @@ Enter your solution below.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/rock_paper_scissors_genserver.livemd
+++ b/exercises/rock_paper_scissors_genserver.livemd
@@ -143,7 +143,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/rock_paper_scissors_lizard_spock.livemd
+++ b/exercises/rock_paper_scissors_lizard_spock.livemd
@@ -118,7 +118,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/rollable_expressions.livemd
+++ b/exercises/rollable_expressions.livemd
@@ -79,7 +79,7 @@ Utils.feedback(:rollable_expressions, Rollable)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/rpg_abilities.livemd
+++ b/exercises/rpg_abilities.livemd
@@ -179,7 +179,7 @@ For example, you might create a `Castable` protocol for spells the character can
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/rpg_dialogue.livemd
+++ b/exercises/rpg_dialogue.livemd
@@ -259,7 +259,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/rps_pattern_matching.livemd
+++ b/exercises/rps_pattern_matching.livemd
@@ -45,7 +45,7 @@ Utils.feedback(:rock_paper_scissors_pattern_matching, RockPaperScissors)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/rubix_cube.livemd
+++ b/exercises/rubix_cube.livemd
@@ -45,7 +45,7 @@ You might consider using [Visual Studio Code Live Share](https://code.visualstud
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/save_game.livemd
+++ b/exercises/save_game.livemd
@@ -61,7 +61,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/school_grades.livemd
+++ b/exercises/school_grades.livemd
@@ -134,7 +134,7 @@ Utils.feedback(:school_grades, School)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/shopping_list.livemd
+++ b/exercises/shopping_list.livemd
@@ -112,7 +112,7 @@ shopping_cart = []
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/sign_up_form.livemd
+++ b/exercises/sign_up_form.livemd
@@ -58,7 +58,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/smart_cache.livemd
+++ b/exercises/smart_cache.livemd
@@ -56,7 +56,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/snowman_script.livemd
+++ b/exercises/snowman_script.livemd
@@ -94,7 +94,7 @@ __( :  )|_
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/spoonacular_recipe_api.livemd
+++ b/exercises/spoonacular_recipe_api.livemd
@@ -35,7 +35,7 @@ Use [HTTPoison](https://hexdocs.pm/httpoison/HTTPoison.html) to retrieve the sam
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/stack.livemd
+++ b/exercises/stack.livemd
@@ -48,7 +48,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/sublist.livemd
+++ b/exercises/sublist.livemd
@@ -45,7 +45,7 @@ Utils.feedback(:sublist, Sublist)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/supervised_stack.livemd
+++ b/exercises/supervised_stack.livemd
@@ -78,7 +78,7 @@ start the `Stack` process under a supervisor so that it will restart with an emp
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/tailwind_components.livemd
+++ b/exercises/tailwind_components.livemd
@@ -74,7 +74,7 @@ You can use https://picsum.photos/200/100 to retrieve a fake image:
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/tic-tac-toe.livemd
+++ b/exercises/tic-tac-toe.livemd
@@ -106,7 +106,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/timeline.livemd
+++ b/exercises/timeline.livemd
@@ -44,7 +44,7 @@ Utils.feedback(:timeline, Timeline)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/todo_list.livemd
+++ b/exercises/todo_list.livemd
@@ -214,7 +214,7 @@ TodoList.all_items(%{"My"})
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/traffic_light_server.livemd
+++ b/exercises/traffic_light_server.livemd
@@ -434,7 +434,7 @@ You may find the following commented cell useful for testing your solution.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/treasure_matching.livemd
+++ b/exercises/treasure_matching.livemd
@@ -143,7 +143,7 @@ Utils.feedback(:jewel, jewel)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/typing_game.livemd
+++ b/exercises/typing_game.livemd
@@ -106,7 +106,7 @@ Your word: blue
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/video_game_spawner.livemd
+++ b/exercises/video_game_spawner.livemd
@@ -87,7 +87,7 @@ Upon terminating, the `Spawner` supervisor should automatically restart the `Cre
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/weighted_voting.livemd
+++ b/exercises/weighted_voting.livemd
@@ -81,7 +81,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/exercises/wordle_application.livemd
+++ b/exercises/wordle_application.livemd
@@ -94,7 +94,7 @@ Add the following additional test cases and ensure you code passes.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/apis.livemd
+++ b/reading/apis.livemd
@@ -242,7 +242,7 @@ response
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/arithmetic.livemd
+++ b/reading/arithmetic.livemd
@@ -530,7 +530,7 @@ Utils.feedback(:remainder, remainder)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/atoms.livemd
+++ b/reading/atoms.livemd
@@ -156,7 +156,7 @@ Check if `false` is equal to `:false`.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/behaviours.livemd
+++ b/reading/behaviours.livemd
@@ -165,7 +165,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/benchmarking.livemd
+++ b/reading/benchmarking.livemd
@@ -184,7 +184,7 @@ Benchee.run(%{
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/big_o_notation.livemd
+++ b/reading/big_o_notation.livemd
@@ -447,7 +447,7 @@ Utils.table(:factorial_complexity)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/bitstrings.livemd
+++ b/reading/bitstrings.livemd
@@ -381,7 +381,7 @@ Utils.feedback(:cypher, Cypher)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/book_search_authors.livemd
+++ b/reading/book_search_authors.livemd
@@ -1100,7 +1100,7 @@ However, this question doesn't have a simple answer! In this case, we've decided
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/book_search_book_content.livemd
+++ b/reading/book_search_book_content.livemd
@@ -786,7 +786,7 @@ In your seed file, change the size of `:content` in `:book_contents` to be signi
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/book_search_books.livemd
+++ b/reading/book_search_books.livemd
@@ -1814,7 +1814,7 @@ For more on Ecto and Phoenix, consider the following resources.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/book_search_tags.livemd
+++ b/reading/book_search_tags.livemd
@@ -1345,7 +1345,7 @@ We can visit http://localhost:4000/books and filter books by tags.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/booleans.livemd
+++ b/reading/booleans.livemd
@@ -296,7 +296,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/built-in_modules.livemd
+++ b/reading/built-in_modules.livemd
@@ -957,7 +957,7 @@ For further practice, we highly recommend the excellent [exercism.org](https://e
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/caching_agent_ets.livemd
+++ b/reading/caching_agent_ets.livemd
@@ -516,7 +516,7 @@ For more information, consider reading:
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/comments.livemd
+++ b/reading/comments.livemd
@@ -71,7 +71,7 @@ In the Elixir cell below, comment all of the code out using the **Toggle lines c
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/comparison_operators.livemd
+++ b/reading/comparison_operators.livemd
@@ -135,7 +135,7 @@ Utils.form(:comparison_operators)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/comprehensions.livemd
+++ b/reading/comprehensions.livemd
@@ -364,7 +364,7 @@ Enum.map(1..3, fn a -> Enum.map(1..3, fn b -> {a, b} end) end)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/computer_hardware.livemd
+++ b/reading/computer_hardware.livemd
@@ -210,7 +210,7 @@ In addition, performance issues generally have a more significant impact on lowe
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/control_flow.livemd
+++ b/reading/control_flow.livemd
@@ -829,7 +829,7 @@ The conditions for `grade` should be:
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/datetime.livemd
+++ b/reading/datetime.livemd
@@ -270,7 +270,7 @@ to ensure it is correct.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/deprecated_binary.livemd
+++ b/reading/deprecated_binary.livemd
@@ -231,7 +231,7 @@ In the Elixir cell below, enter the codepoint for the letter `"Y"`. You're allow
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/deprecated_divide_and_conquer.livemd
+++ b/reading/deprecated_divide_and_conquer.livemd
@@ -542,7 +542,7 @@ Benchee.run(
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/documentation_and_static_analysis.livemd
+++ b/reading/documentation_and_static_analysis.livemd
@@ -397,7 +397,7 @@ You can even write your own custom credo checks, or configure additional credo c
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/ecto.livemd
+++ b/reading/ecto.livemd
@@ -766,7 +766,7 @@ There are also several lessons by Elixir Schools you may find useful.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/ecto_changeset.livemd
+++ b/reading/ecto_changeset.livemd
@@ -329,7 +329,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/enum.livemd
+++ b/reading/enum.livemd
@@ -868,7 +868,7 @@ We have several exercises dedicated to the [Enum](https://hexdocs.pm/elixir/Enum
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/erlang_atoms.livemd
+++ b/reading/erlang_atoms.livemd
@@ -48,7 +48,7 @@ You can find the full list of elements [here](https://ptable.com/?lang=en#Proper
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/exunit.livemd
+++ b/reading/exunit.livemd
@@ -967,7 +967,7 @@ For more on testing, consider using the following resources.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/file.livemd
+++ b/reading/file.livemd
@@ -472,7 +472,7 @@ Utils.feedback(:copy_file, "copied_example")
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/functions.livemd
+++ b/reading/functions.livemd
@@ -510,7 +510,7 @@ Utils.feedback(:pipe_operator, answer)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/generic_server.livemd
+++ b/reading/generic_server.livemd
@@ -428,7 +428,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/guards.livemd
+++ b/reading/guards.livemd
@@ -252,7 +252,7 @@ Utils.feedback(:percent, Percent)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/html_css.livemd
+++ b/reading/html_css.livemd
@@ -1172,7 +1172,7 @@ For experimenting with HTML and CSS, we recommend sites such as [CodePen](https:
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/iex.livemd
+++ b/reading/iex.livemd
@@ -287,7 +287,7 @@ For more, consider reading the following:
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/keyword_lists.livemd
+++ b/reading/keyword_lists.livemd
@@ -118,7 +118,7 @@ Remove `[two: 2]` from `[one: 1, two: 2]` to make `[one: 1]`.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/lists.livemd
+++ b/reading/lists.livemd
@@ -266,7 +266,7 @@ list = [1, 2, 3]
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/lists_vs_tuples.livemd
+++ b/reading/lists_vs_tuples.livemd
@@ -582,7 +582,7 @@ Utils.form(:lists_vs_tuples)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/maps.livemd
+++ b/reading/maps.livemd
@@ -239,7 +239,7 @@ Utils.feedback(:update_map, updated_map)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/maps_mapsets_keyword_lists.livemd
+++ b/reading/maps_mapsets_keyword_lists.livemd
@@ -206,7 +206,7 @@ the element `2`. Your answer should return `true`.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/match_operator.livemd
+++ b/reading/match_operator.livemd
@@ -304,7 +304,7 @@ hello = "world!"
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/metaprogramming.livemd
+++ b/reading/metaprogramming.livemd
@@ -498,7 +498,7 @@ Usage.hello()
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/mix.livemd
+++ b/reading/mix.livemd
@@ -521,7 +521,7 @@ For more on [Mix](https://hexdocs.pm/mix/Mix.html), consider reading the followi
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/modules.livemd
+++ b/reading/modules.livemd
@@ -500,7 +500,7 @@ In the Elixir cell below, define a module with a function that uses a default ar
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/non_enumerables.livemd
+++ b/reading/non_enumerables.livemd
@@ -178,7 +178,7 @@ Enum.join(["a", "b", "c"], "_")
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/pattern_matching.livemd
+++ b/reading/pattern_matching.livemd
@@ -582,7 +582,7 @@ expected = actual
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/persistence.livemd
+++ b/reading/persistence.livemd
@@ -327,7 +327,7 @@ You will have the opportunity to learn more about Ecto and get hands-on experien
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/phoenix.livemd
+++ b/reading/phoenix.livemd
@@ -1190,7 +1190,7 @@ For more on Phoenix, consider the following resources.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/phoenix_and_ecto.livemd
+++ b/reading/phoenix_and_ecto.livemd
@@ -661,7 +661,7 @@ You should handle the `:index`, `:edit`, `:new`, `:show`, `:create`, `:update`, 
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/phoenix_and_ecto_relationships.livemd
+++ b/reading/phoenix_and_ecto_relationships.livemd
@@ -1342,7 +1342,7 @@ $ mix test
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/phoenix_authentication.livemd
+++ b/reading/phoenix_authentication.livemd
@@ -1148,7 +1148,7 @@ Consider the following resources as you continue to learn more about authorizati
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/pipe_operator.livemd
+++ b/reading/pipe_operator.livemd
@@ -94,7 +94,7 @@ add_blueberries.(add_pizza.(add_blueberries.(add_pizza.(add_grapes.([])))))
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/polymorphism.livemd
+++ b/reading/polymorphism.livemd
@@ -118,7 +118,7 @@ Running is one example, can you think of others?
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/processes.livemd
+++ b/reading/processes.livemd
@@ -357,7 +357,7 @@ end
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/protocols.livemd
+++ b/reading/protocols.livemd
@@ -259,7 +259,7 @@ Sound.say(%Dog{})
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/ranges.livemd
+++ b/reading/ranges.livemd
@@ -113,7 +113,7 @@ Utils.feedback(:range_to_list, answer)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/rdbms.livemd
+++ b/reading/rdbms.livemd
@@ -487,7 +487,7 @@ you might consider the following resources.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/recursion.livemd
+++ b/reading/recursion.livemd
@@ -298,7 +298,7 @@ Utils.feedback(:custom_enum_map, CustomEnum)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/regex.livemd
+++ b/reading/regex.livemd
@@ -451,7 +451,7 @@ apply to Elixir.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/scripts.livemd
+++ b/reading/scripts.livemd
@@ -152,7 +152,7 @@ you will learn about in the next sections.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/streams.livemd
+++ b/reading/streams.livemd
@@ -478,7 +478,7 @@ I.e. $1^3, 2^3, 3^3, 4^3, ...$ which would be `[1, 8, 27 , 64]` and so on.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/strings.livemd
+++ b/reading/strings.livemd
@@ -133,7 +133,7 @@ Utils.feedback(:string_interpolation, answer)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/structs.livemd
+++ b/reading/structs.livemd
@@ -244,7 +244,7 @@ For more on structs, you can read
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/supervised_mix_project.livemd
+++ b/reading/supervised_mix_project.livemd
@@ -384,7 +384,7 @@ so we can keep playing. That's the definition of fault-tolerance!
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/supervisors.livemd
+++ b/reading/supervisors.livemd
@@ -393,7 +393,7 @@ Predict the crash timeline, Then evaluate your code. Did the result match your p
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/tailwind.livemd
+++ b/reading/tailwind.livemd
@@ -523,7 +523,7 @@ Refer to the [Tailwind Documentation](https://tailwindcss.com/docs/installation)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/task.livemd
+++ b/reading/task.livemd
@@ -238,7 +238,7 @@ For more on [Task](https://hexdocs.pm/elixir/Task.html), consider reading:
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/testing_genservers.livemd
+++ b/reading/testing_genservers.livemd
@@ -230,7 +230,7 @@ Counter.decrement(pid)
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/tuples.livemd
+++ b/reading/tuples.livemd
@@ -55,7 +55,7 @@ the second element.
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/reading/web_servers.livemd
+++ b/reading/web_servers.livemd
@@ -174,7 +174,7 @@ Visit http://localhost:4000 to see your modified content. You may need to stop t
 
 ## Commit Your Progress
 
-Run the following in your command line from the project folder to track and save your progress in a Git commit.
+Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
 ```
 $ git add .

--- a/utils/lib/mix/tasks/add_git_section.ex
+++ b/utils/lib/mix/tasks/add_git_section.ex
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Bc.AddGitSection do
 
     ## Commit Your Progress
 
-    Run the following in your command line from the project folder to track and save your progress in a Git commit.
+    Run the following in your command line from the beta_curriculum folder to track and save your progress in a Git commit.
 
     ```
     $ git add .


### PR DESCRIPTION
Replaced 'project' with 'beta_curriculum' in `## Commit your progress` section of all applicable pages.