### PR TITLE
Issue #347 - fix Custom Maze exercise test

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,8 @@
 		"samuel-pordeus.elixir-test",
 		"jakebecker.elixir-ls",
 		"ms-vsliveshare.vsliveshare",
-		"streetsidesoftware.code-spell-checker"
+		"streetsidesoftware.code-spell-checker",
+		"msaraiva.surface"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []

--- a/exercises/mazes.livemd
+++ b/exercises/mazes.livemd
@@ -136,7 +136,7 @@ custom_maze = nil
 
 path = nil
 
-Utils.feedback(:custom_maze, [custom_maze, nil])
+Utils.feedback(:custom_maze, [custom_maze, path])
 ```
 
 ## Treasure Map


### PR DESCRIPTION
Test was asserting `nil == "Exit!"` which will always fail. 
Updated so the test is passed the `path` variable and not `nil`