### PR TITLE
Issue #347 , fixed Utils.Feedback input

### DIFF
--- a/exercises/mazes.livemd
+++ b/exercises/mazes.livemd
@@ -136,7 +136,7 @@ custom_maze = nil
 
 path = nil
 
-Utils.feedback(:custom_maze, [custom_maze, nil])
+Utils.feedback(:custom_maze, [custom_maze, path])
 ```
 
 ## Treasure Map


### PR DESCRIPTION
Utils.feedback was passed `nil` as the second item in the list to check rather than the expected `path` variable to be populated by the student.