### PR TITLE
Issue 371 - Remove reference to unused extension

### DIFF
--- a/reading/code_editors.livemd
+++ b/reading/code_editors.livemd
@@ -88,7 +88,6 @@ With the curriculum project open in visual studio code, open the Extensions tab 
 We recommend you install them all.
 
 * **Phoenix Framework**: Syntax highlighting for Phoenix HEEx files.
-* **Surface**: Syntax highlighting for Surface UI.
 * **Elixir Test**: Useful commands for testing Elixir code.
 * **ElixirLS**: General Elixir support for autocomplete, syntax highlighting, and more
 * **Live Share**: Real-time collaborative development.


### PR DESCRIPTION
Remove in text reference to unused VSCode extension for Surface UI
Extension is currently not a recommended install in extensions.json