### PR TITLE
Fix hint in Enum Livebook.

### DIFF
--- a/reading/enum.livemd
+++ b/reading/enum.livemd
@@ -344,7 +344,7 @@ Use [Enum.reduce/3](https://hexdocs.pm/elixir/Enum.html#reduce/3) or [Enum.reduc
   <summary>Hint</summary>
 
   ```elixir
-  Enum.reduce(1..10, fn int, acc -> 
+  Enum.reduce(1..10, 0, fn int, acc -> 
     if rem(int, 2) == 0 do
       acc + int
       else


### PR DESCRIPTION
The hint currently does not match the expected solution. You need to pass in the initial `acc` value else `reduce/2` will use the first value of the collection.