### PR TITLE
Fixed two typos

### DIFF
--- a/reading/comprehensions.livemd
+++ b/reading/comprehensions.livemd
@@ -93,7 +93,7 @@ for {:keep, value} <- [keep: 1, keep: 2, filter: 1, filter: 3] do
 end
 ```
 
-Here's where comprehensions get cool and stop looking like for loops. You can use multiple comma-separate
+Here's where comprehensions get cool and stop looking like loops. You can use multiple comma-separated
 generators in a single comprehension.
 
 The comprehension treats each additional generator like a nested loop. For each element in the first loop, it will enumerate through every element in the second loop.


### PR DESCRIPTION
Found two typos in the Comprehensions lesson

Here's where comprehensions get cool and stop **looking like for** loops -> Changed into "looking like"
You can use multiple **comma-separate** generators in a single comprehension. -> Changed into "comma-separated"