### PR TITLE
Fixed three typos

### DIFF
--- a/reading/comprehensions.livemd
+++ b/reading/comprehensions.livemd
@@ -93,7 +93,7 @@ for {:keep, value} <- [keep: 1, keep: 2, filter: 1, filter: 3] do
 end
 ```
 
-Here's where comprehensions get cool and stop looking like for loops. You can use multiple comma-separate
+Here's where comprehensions get cool and stop looking like loops. You can use multiple comma-separated
 generators in a single comprehension.
 
 The comprehension treats each additional generator like a nested loop. For each element in the first loop, it will enumerate through every element in the second loop.
@@ -327,7 +327,7 @@ In the Elixir cell below, convert the following `Enum.map` into a comprehension.
 <!-- livebook:{"force_markdown":true} -->
 
 ```elixir
-Enum.map(1...5, fn each -> each * 2 end)
+Enum.map(1..5, fn each -> each * 2 end)
 [2, 4, 6, 8, 10]
 ```
 


### PR DESCRIPTION
I have fixed the following typo in a cell code:

`Enum.map(1...5)`

It would be worth double checking that the prior two typos are still fixed. I did so in my current branch to be sure.

Here's where comprehensions get cool and stop looking **like for** loops.
You can use multiple **comma-separate** generators in a single comprehension.