### PR TITLE
Fix hint example solution sections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,7 +257,7 @@ If you fix DockYard Academy Content or submit new content, please keep the follo
 - Each major concept should have a new section. In addition, each section should try to provide at least one student interaction portion, typically using the **Your Turn** heading.
 - **Hints** and **Example Solutions** should be provided using the details component (these styles look nicer in Livebook):
 
-<details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
+<details style="background-color: burlywood; padding: 1rem; margin: 1rem 0;">
 <summary>Hint</summary>
 
 Have you tried turning it off and on again?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,7 +255,7 @@ If you fix DockYard Academy Content or submit new content, please keep the follo
 - Text should be run through [grammarly](https://app.grammarly.com/) or an alternative grammar checking program to ensure correctness. The free Grammarly features should be sufficient.
 - Lessons should have a hidden setup section at the top of the Livebook for any necessary dependencies.
 - Each major concept should have a new section. In addition, each section should try to provide at least one student interaction portion, typically using the **Your Turn** heading.
-- **Hints** and **Possible Solutions** should be provided using the details component (these styles look nicer in Livebook):
+- **Hints** and **Example Solutions** should be provided using the details component (these styles look nicer in Livebook):
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
 <summary>Hint</summary>

--- a/exercises/animal_generator.livemd
+++ b/exercises/animal_generator.livemd
@@ -32,7 +32,7 @@ ages = 1..14
 
 Your list of animals should include every permutation of names, species, and ages. There are `126` permutations in the data examples above.
 
-<details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
+<details style="background-color: burlywood; padding: 1rem; margin: 1rem 0;">
 <summary>Hint</summary>
 
 Consider using `names`, `animal_types`, and `ages` as generators for a comprehension.

--- a/exercises/animal_generator.livemd
+++ b/exercises/animal_generator.livemd
@@ -40,7 +40,7 @@ Consider using `names`, `animal_types`, and `ages` as generators for a comprehen
 </details>
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Possible Solution</summary>
+<summary>Example Solution</summary>
 
 ```elixir
 names = ["Clifford", "Zoboomafoo", "Leonardo"]

--- a/exercises/card_counting.livemd
+++ b/exercises/card_counting.livemd
@@ -59,7 +59,7 @@ In order to track if there are more high cards left in the deck, or low cards le
 Bind integers `low`, `normal`, and `high` to track the amount to increase or decrease the current count by. You will use these variables in further exercises.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 low = -1
@@ -80,7 +80,7 @@ Enter your solution below.
 The initial count is `0`. You have been dealt one **high** card. Use arithmetic operators and the bound variables above to determine the new count.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 initial_count = 0
@@ -100,7 +100,7 @@ Enter your solution below.
 The initial count is `0`. You have been dealt one **low** card. Use arithmetic operators and the bound variables above to determine the new count.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 initial_count = 0
@@ -120,7 +120,7 @@ Enter your solution below.
 The initial count is `5`. You have been dealt five **high** cards, two **low** cards, and two **normal** cards. Use arithmetic operators and the bound variables above to determine the new count.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 initial_count = 5
@@ -150,7 +150,7 @@ random_card = Enum.random(1..13)
 Generate three random cards, use the values of the three randomly generated cards to determine the current count given the initial count is `0`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 random_card1 = Enum.random(1..13)

--- a/exercises/custom_enum_with_reduce.livemd
+++ b/exercises/custom_enum_with_reduce.livemd
@@ -19,7 +19,7 @@ Mix.install([
 You're going to use [Enum.reduce/2](https://hexdocs.pm/elixir/Enum.html#reduce/2) and/or [Enum.reduce/3](https://hexdocs.pm/elixir/Enum.html#reduce/3) to re-implement several of the [Enum](https://hexdocs.pm/elixir/Enum.html) module's functions. Only implement these functions for **lists**.
 
 <details style="background-color: lightgreen; padding: 1rem;">
-<summary>Possible Solution</summary>
+<summary>Example Solution</summary>
 
 ```elixir
 defmodule CustomEnum do

--- a/exercises/dominoes.livemd
+++ b/exercises/dominoes.livemd
@@ -59,7 +59,7 @@ For example:
 * `Domino1` receives the `:fall` message. `Domino1` crashes. `Domino2` then `Domino3` are terminated by the supervisor.
 * `Domino2` receives the `:fall` message. `Domino2` crashes. `Domino3` is terminated by the supervisor.
 
-<details>
+<details style="background-color: burlywood; padding: 1rem; margin: 1rem 0;">
 <summary>Hint</summary>
 Use the <code>:rest_for_one</code> strategy for your supervisor.
 </details>

--- a/exercises/family_tree.livemd
+++ b/exercises/family_tree.livemd
@@ -103,7 +103,7 @@ classDiagram
 <!-- livebook:{"break_markdown":true} -->
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 This is an example of **nested data**.
 

--- a/exercises/fun_formulas.livemd
+++ b/exercises/fun_formulas.livemd
@@ -41,7 +41,7 @@ For example if we complete `7` out of `10` items, we would be `70.0%` complete.
 Use arithmetic operators to determine the **percentage** given we have completed `12` out of `42` items.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 actual = 12
@@ -67,7 +67,7 @@ Users can enter the `mass` and `acceleration` of a ship to visualize the `force`
 Given that ${mass} * {acceleration} = force$, calculate the force when mass is `10` and acceleration is `50`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 mass = 10
@@ -91,7 +91,7 @@ It's common in many cultures to leave a tip whenever you buy a meal. It's common
 Given the initial cost of a meal is `20`, and you want to leave a `15%` tip, use arithmetic operators to determine the total cost of the meal.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 initial_cost = 20
@@ -115,7 +115,7 @@ To calculate the longest side of a triangle we use $a^2 + b^2 = c^2$
 Given a triangle where side $a$ is `4`, and side $b$ is `10`, calculate $c^2$
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 a = 4
@@ -137,7 +137,7 @@ Enter your solution below.
 Earlier we calculated $c^2$ for pythagoream theorum. Given $c^2$ is `116` determine the square root of $c^2$ to calculate $c$.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 c_squared = 116

--- a/exercises/guessing_games.livemd
+++ b/exercises/guessing_games.livemd
@@ -21,7 +21,7 @@ Create a word guessing game. Manually bind a `guess` and an `answer`. Return `"C
 Ensure your solutions works for both an incorrect and correct player guess.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Possible Solution</summary>
+  <summary>Example Solution</summary>
 
   ```elixir
   guess = "hello"
@@ -53,7 +53,7 @@ Armed with this knowledge, you're going to create a word guessing game.
 * If the `guess` matches the answer, return `"Correct!"`, otherwise return `"Incorrect."`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Possible Solution</summary>
+  <summary>Example Solution</summary>
 
   ```elixir
   guess = "hello"
@@ -87,7 +87,7 @@ Now let's build a number guessing game
 * If the `guess` is higher than the answer, return `"Too high!"`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Possible Solution</summary>
+  <summary>Example Solution</summary>
 
 
   `cond` allows us to handle several different conditions.

--- a/exercises/habit_tracker.livemd
+++ b/exercises/habit_tracker.livemd
@@ -40,7 +40,7 @@ flowchart
 Bind a variable `small`, `medium`, and `large` to represent the point value as an integer (see above) for each habit. You will use these variables in further solutions.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 large = 30
@@ -72,7 +72,7 @@ flowchart LR
 ```
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 small + medium + large
@@ -91,7 +91,7 @@ Enter your answer in the code cell below.
 Given a user has completed **ten small** habits, **five medium** habits, and **three large** habits, use arithmetic operators to determine how many points they have in total.
 
 <details style="background-color: lightgreen; padding: 1rem;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 small * 10 + medium * 5 + large * 3
@@ -112,7 +112,7 @@ Users define a a `goal` number of points to earn each day. Determine what percen
 Remember that you can calculate percentage with $\frac{points}{goal} * 100$
 
 <details style="background-color: lightgreen; padding: 1rem;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 goal = 40
@@ -147,7 +147,7 @@ Determine the users total point score when they complete:
 * two late large habits
 
 <details style="background-color: lightgreen; padding: 1rem;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 goal = 40

--- a/exercises/mad_libs.livemd
+++ b/exercises/mad_libs.livemd
@@ -25,7 +25,7 @@ In the Elixir cell below, bind each blank word to a variable. Then use **string 
 > A programmer is a ____ that turns ____ into ____.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 blank1 = "person"
@@ -50,7 +50,7 @@ In the Elixir cell below, bind each blank word to a variable. Then use **string 
 > ____ and ____ combined makes ____.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 blank1 = "foo"

--- a/exercises/mazes.livemd
+++ b/exercises/mazes.livemd
@@ -39,7 +39,7 @@ We've created a map that represents the following maze. Each cardinal direction 
 Use **map.key** notation to access the `"Exit!"` string.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 maze = %{
@@ -92,7 +92,7 @@ Use use **map[key]** notation to access the maze and retrieve the `"Exit!"` stri
 <!-- livebook:{"break_markdown":true} -->
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 maze = %{
@@ -149,7 +149,7 @@ You have been given a treasure map (pun intended). That will lead you to `"gold"
 Use **map[key]** and/or **map.key** notation to retrieve the `"gold"` value in the `treasure_map`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 treasure_map = %{
@@ -192,7 +192,7 @@ treasure_map = %{
 Use map update syntax to create a update the original `treasure_map` such that the `"gold"` is now `"taken"`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 treasure_map = %{

--- a/exercises/pokemon_battle.livemd
+++ b/exercises/pokemon_battle.livemd
@@ -151,7 +151,7 @@ classDiagram
 Use may these three structs to test your `Pokemon.attack/2` function.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 charmander = %Pokemon{name: "Charmander", type: :fire, health: 20, attack: 5, speed: 20}

--- a/exercises/pokemon_server.livemd
+++ b/exercises/pokemon_server.livemd
@@ -71,7 +71,7 @@ Pokemon.attack(attacker, defender)
 ```
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Possible Solution</summary>
+  <summary>Example Solution</summary>
 
 ```elixir
 defmodule Pokemon do

--- a/exercises/rock_paper_scissors.livemd
+++ b/exercises/rock_paper_scissors.livemd
@@ -38,7 +38,7 @@ player_choice = Enum.random([:rock, :paper, :scissors])
 Then, return the winning choice of either `:rock`, `:paper`, or `:scissors` that beats the player's choice.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
   ```elixir
   player_choice = :scissors
@@ -68,7 +68,7 @@ Bind a `player1_choice` and `player2_choice` variable to `:rock`, `:paper`, or `
 * If both players have the same choice, then return `"Draw"`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
   ```elixir
   player1 = :rock

--- a/exercises/rpg_dialogue.livemd
+++ b/exercises/rpg_dialogue.livemd
@@ -21,7 +21,7 @@ In this exercise, you will create dialogue for an RPG (Role Playing Game).
 To generate this dialogue define a `Character` struct with a `:name`, `:class`, and `:weapon` keys. Enforce that the `:name` key must have a value.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 defmodule Character do
@@ -160,7 +160,7 @@ classDiagram
 Use may these three structs to test your `Character` functions.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 aragorn = %Character{name: "Aragorn", class: "ranger", weapon: "sword"}

--- a/exercises/shopping_list.livemd
+++ b/exercises/shopping_list.livemd
@@ -31,7 +31,7 @@ In the Elixir cells below, use `++` and `--` to add the items shown.
 * Add three `"banana"`s to the `shopping_cart`
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 shopping_cart = []
@@ -133,7 +133,7 @@ items from the `shopping_cart`
 * Remove `5` `candies` (Notice `5` and not `10`!).
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 shopping_cart = []

--- a/exercises/tic-tac-toe.livemd
+++ b/exercises/tic-tac-toe.livemd
@@ -88,7 +88,7 @@ TicTacToe.fill(board, {0, 1}, "O")
 
 Implement the `TicTacToe` module as documented.
 
-<details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
+<details style="background-color: burlywood; padding: 1rem; margin: 1rem 0;">
 <summary>Hint</summary>
 
 Remember that `Enum.at` can access a list at an index, however our coordinates are flipped

--- a/exercises/todo_list.livemd
+++ b/exercises/todo_list.livemd
@@ -200,7 +200,7 @@ It should be able to search by the `:title`. It should also search by partially 
 
 So `"My"` would find `"My Title"`
 
-<details>
+<details style="background-color: burlywood; padding: 1rem; margin: 1rem 0;">
   <summary>Hint</summary>
   You could filter using the <code>Enum</code> module, however, it will be more performant to rely on <code>Ecto.Query</code>..
 </details>

--- a/reading/arithmetic.livemd
+++ b/reading/arithmetic.livemd
@@ -403,7 +403,7 @@ YouTube.new("https://www.youtube.com/watch?v=XZRQhkii0h0")
 In the Elixir cell below, Use the `**` operator to determine `10` to the power of `214`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 10 ** 214
@@ -479,7 +479,7 @@ In the Elixir cell below,
 Use brackets `()` to alter the return value of the expression below to be `200` instead of `110`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 (10 + 10) * 10
@@ -570,7 +570,7 @@ style 9 fill:lightcoral
 ```
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 rem(10, 3)

--- a/reading/built-in_modules.livemd
+++ b/reading/built-in_modules.livemd
@@ -56,7 +56,7 @@ elem({3, 6, 9}, 0)
 Use [Kernel.elem/2](https://hexdocs.pm/elixir/Kernel.html#elem/2) to retrieve `100` from the following tuple.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -86,7 +86,7 @@ true = Kernel.is_integer(1)
 Use the [Kernel](https://hexdocs.pm/elixir/Kernel.html) module to check the types of each value in the cells below. You may have to read through the [Kernel Documentation](https://hexdocs.pm/elixir/Kernel.html) to find the appropriate functions.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -160,7 +160,7 @@ We want to prevent `seconds` from being less than `0` seconds, and more than `59
 Created a `capped_seconds` variable that uses the value of `seconds` and cannot go above `59` seconds or below `0` seconds.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -206,7 +206,7 @@ map = %{}
 Use [Kernel.inspect/2](https://hexdocs.pm/elixir/Kernel.html#inspect/2) to safely interpolate the following variables inside of a string.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -377,7 +377,7 @@ flowchart TB
 Use the [String.at/2](https://hexdocs.pm/elixir/String.html#at/2) function to get the character at index `2` of `"hello"`. The result should be the character `l`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -393,7 +393,7 @@ Use the [String.at/2](https://hexdocs.pm/elixir/String.html#at/2) function to ge
 Use the [String.at/2](https://hexdocs.pm/elixir/String.html#at/2) function to retrieve the letter `"o"` in `"hello"`
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -409,7 +409,7 @@ Use the [String.at/2](https://hexdocs.pm/elixir/String.html#at/2) function to re
 Use the [String.contains?/2](https://hexdocs.pm/elixir/String.html#contains?/2) function to determine if `"hello"` contains `"lo"`. The result should be `true`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -425,7 +425,7 @@ Use the [String.contains?/2](https://hexdocs.pm/elixir/String.html#contains?/2) 
 Use [String.capitalize/2](https://hexdocs.pm/elixir/String.html#capitalize/2) to capitalize `"hello"` to `"Hello"`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -441,7 +441,7 @@ Use [String.capitalize/2](https://hexdocs.pm/elixir/String.html#capitalize/2) to
 Use [String.upcase/2](https://hexdocs.pm/elixir/String.html#upcase/2) to upcase `"hello"` to `"HELLO"`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -457,7 +457,7 @@ Use [String.upcase/2](https://hexdocs.pm/elixir/String.html#upcase/2) to upcase 
 Use [String.downcase/2](https://hexdocs.pm/elixir/String.html#downcase/2) to dowcase `"HELLO"` to `"hello"`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -473,7 +473,7 @@ Use [String.downcase/2](https://hexdocs.pm/elixir/String.html#downcase/2) to dow
 Use [String.split/3](https://hexdocs.pm/elixir/String.html#split/3) to split the following comma-separated list of strings into a list of words.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -489,7 +489,7 @@ Use [String.split/3](https://hexdocs.pm/elixir/String.html#split/3) to split the
 Use [String.trim/1](https://hexdocs.pm/elixir/String.html#trim/1) to remove whitespace from the `"  hello!  "` string.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -560,7 +560,7 @@ the list below.
 Use [List.delete_at/2](https://hexdocs.pm/elixir/List.html#delete_at/2) to remove `2` from this list.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -576,7 +576,7 @@ Use [List.delete_at/2](https://hexdocs.pm/elixir/List.html#delete_at/2) to remov
 Use [List.flatten/1](https://hexdocs.pm/elixir/List.html#flatten/1) to flatten the following list into `[1, 2, 3, 4, 5, 6, 7, 8, 9]`
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -592,7 +592,7 @@ Use [List.flatten/1](https://hexdocs.pm/elixir/List.html#flatten/1) to flatten t
 Use [List.insert_at/3](https://hexdocs.pm/elixir/List.html#insert_at/3) to insert `2` into the following list to make `[1, 2, 3]`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -608,7 +608,7 @@ Use [List.insert_at/3](https://hexdocs.pm/elixir/List.html#insert_at/3) to inser
 Use [List.last/2](https://hexdocs.pm/elixir/List.html#last/2) to retrieve the last element `10000` in a list from `1` to `10000`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -630,7 +630,7 @@ Enum.to_list(1..10000)
 Use [List.update_at/3](https://hexdocs.pm/elixir/List.html#update_at/3) to subtract `2` from `4` in the following list to make `[1, 2, 3]`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -646,7 +646,7 @@ Use [List.update_at/3](https://hexdocs.pm/elixir/List.html#update_at/3) to subtr
 Use [List.zip/1](https://hexdocs.pm/elixir/List.html#zip/1) to combine these two lists to make `[{"a", 1}, {"b", 2}, {"c", 3}]`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -707,7 +707,7 @@ new_map
 Use [Map.get/3](https://hexdocs.pm/elixir/Map.html#get/3) to retrieve the `"world"` value for the `:hello` key in the following map.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -723,7 +723,7 @@ Use [Map.get/3](https://hexdocs.pm/elixir/Map.html#get/3) to retrieve the `"worl
 Use [Map.put/3](https://hexdocs.pm/elixir/Map.html#put/3) to add the key `:two` with the value `2` to the following map.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -739,7 +739,7 @@ Use [Map.put/3](https://hexdocs.pm/elixir/Map.html#put/3) to add the key `:two` 
 Use [Map.keys/1](https://hexdocs.pm/elixir/Map.html#keys/1) to retrieve the keys for the following map.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -755,7 +755,7 @@ Use [Map.keys/1](https://hexdocs.pm/elixir/Map.html#keys/1) to retrieve the keys
 Use [Map.delete/2](https://hexdocs.pm/elixir/Map.html#delete/2) to remove `:key1` from the following map.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -803,7 +803,7 @@ Use [Map.update/4](https://hexdocs.pm/elixir/Map.html#update/4) or [Map.update!/
 Use [Map.values/1](https://hexdocs.pm/elixir/Map.html#values/1) to retrieve the values `[1, 2, 3]` in the following map.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -866,7 +866,7 @@ MyIO.inspect("world", label: "hello")
 Use [Keyword.get/3](https://hexdocs.pm/elixir/Keyword.html#get/3) to access the value for the `:color` key in the following keyword list.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -882,7 +882,7 @@ Use [Keyword.get/3](https://hexdocs.pm/elixir/Keyword.html#get/3) to access the 
 Use [Keyword.get/3](https://hexdocs.pm/elixir/Keyword.html#get/3) to access the value for the `:color` key in the following empty list. If the `:color` key does not exist, provide a default value of `"blue"`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -898,7 +898,7 @@ Use [Keyword.get/3](https://hexdocs.pm/elixir/Keyword.html#get/3) to access the 
 Use the [Keyword.keys/1](https://hexdocs.pm/elixir/Keyword.html#keys/1) function to list all of the keys in the following keyword list.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -914,7 +914,7 @@ Use the [Keyword.keys/1](https://hexdocs.pm/elixir/Keyword.html#keys/1) function
 Use the [Keyword.keyword?/1](https://hexdocs.pm/elixir/Keyword.html#keyword?/1) function to determine if the following is a keyword list.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
 
   ```elixir
@@ -930,7 +930,7 @@ Use the [Keyword.keyword?/1](https://hexdocs.pm/elixir/Keyword.html#keyword?/1) 
 Use the [Keyword.keyword?/1](https://hexdocs.pm/elixir/Keyword.html#keyword?/1) function to determine if an empty list is a keyword list.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
   An empty list technically counts as an empty list, because it does not have any elements
   that **don't** follow the `{:atom, term}` keyword list pattern.
@@ -948,7 +948,7 @@ Use the [Keyword.keyword?/1](https://hexdocs.pm/elixir/Keyword.html#keyword?/1) 
 Use the [Keyword.keyword?/1](https://hexdocs.pm/elixir/Keyword.html#keyword?/1) function to determine if the following list is a keyword list.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
   A list is not a keyword list if it has any elements that don't follow the `{:atom, term}` structure.
   ```elixir

--- a/reading/comparison_operators.livemd
+++ b/reading/comparison_operators.livemd
@@ -82,7 +82,7 @@ two equals signs instead of three `==`
 Using comparison operators, determine if `10 + 10 * 15` is greater than `(10 + 10) * 15`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 10 + 10 * 15 > (10 + 10) * 15
@@ -97,7 +97,7 @@ Using comparison operators, determine if `10 + 10 * 15` is greater than `(10 + 1
 Using comparisons operators, determine if `4 ** 6` is equal to `4 * 4 * 4 * 4 * 4 * 4`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 4 ** 6 == 4 * 4 * 4 * 4 * 4 * 4
@@ -112,7 +112,7 @@ Using comparisons operators, determine if `4 ** 6` is equal to `4 * 4 * 4 * 4 * 
 Using comparison operators, determine if `100 / 2` is strictly equal to `50`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 100 / 2 === 50
@@ -162,7 +162,7 @@ Capital letters are always less than lowercase letters regardless of alphabetica
 Use comparison operators to determine if `"hello"` is equal to `"hello"`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 "hello" == "hello"

--- a/reading/comprehensions.livemd
+++ b/reading/comprehensions.livemd
@@ -308,7 +308,7 @@ code points.
 %{"a" => 97, "b" => 98, "c" => 99, "d" => 100}
 ```
 
-<details>
+<details style="background-color: burlywood; padding: 1rem; margin: 1rem 0;">
 <summary>Hint</summary>
 You can use <code>:binary.first/1</code> to convert a variable bound to a string to a codepoint.
 </details>

--- a/reading/control_flow.livemd
+++ b/reading/control_flow.livemd
@@ -96,7 +96,7 @@ recommendation
 Create a thermometer program that determines if the temperature is `:hot`, or `:cold`. Bind a variable `temperature` to a number between `0` and `20`. If the temperature is above `10`, then return `:hot`, otherwise return `:cold`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 temperature = 10
@@ -466,7 +466,7 @@ The conditions for `grade` should be:
 * 1-54 is a D
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 We can solve this problem being very explicit about each condition.
 

--- a/reading/deprecated_divide_and_conquer.livemd
+++ b/reading/deprecated_divide_and_conquer.livemd
@@ -486,7 +486,7 @@ Benchee.run(
 In the Elixir cell below see if you can improve the performance of the `MergeSort` in this new
 `ModifiedMergeSort` module. Ensure its behavior remains the same.
 
-<details>
+<details style="background-color: burlywood; padding: 1rem; margin: 1rem 0;">
 <summary>Hint</summary>
 You might consider removing the assignment of values to variables.
 These intermediate steps may improve readability, but not performance.

--- a/reading/enum.livemd
+++ b/reading/enum.livemd
@@ -341,7 +341,7 @@ Use [Enum.reduce/3](https://hexdocs.pm/elixir/Enum.html#reduce/3) or [Enum.reduc
 ```
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
   ```elixir
   Enum.reduce(1..10, 0, fn int, acc -> 
@@ -564,7 +564,7 @@ Enum.random(1..10)
 Generate a list with ten random integers from `0` to `9`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 Enum.map(1..10, fn _ -> Enum.random(0..9) end)

--- a/reading/functions.livemd
+++ b/reading/functions.livemd
@@ -267,7 +267,7 @@ is_even?.(1) # false
 ```
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 is_even? = fn int -> rem(int, 2) == 0 end 
@@ -333,7 +333,7 @@ calculate_force.(2, 4) # 8
 ```
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 calculate_force = fn mass, acceleration -> mass * acceleration end
@@ -382,7 +382,7 @@ subtract.(20, 25) # -5
 ```
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 subtract = &(&1 - &2)
@@ -408,7 +408,7 @@ multiply_three.(2, 5, 3) # 30
 ```
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 multiply_three = &(&1 * &2 * &3)
@@ -496,7 +496,7 @@ call_with_10_and_20.(add) # 30
 ```
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 call_with_10_and_20 = fn callback -> callback.(10, 20) end
@@ -602,7 +602,7 @@ Use these functions with the pipe operator <span style="background-color: rgb(22
 4. subtract by `4`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 add = fn int1, int2 -> int1 + int2 end

--- a/reading/keyword_lists.livemd
+++ b/reading/keyword_lists.livemd
@@ -88,7 +88,7 @@ List order is guaranteed, so the same is true for keyword lists.
 In the Elixir cell below, create a keyword list of your favourite super hero. Include their `:name` and `:secret_identity`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 [name: "Spiderman", secret_identity: "Peter Parker"]
@@ -180,7 +180,7 @@ value
 Bind `1` in the following keyword list to a variable `one`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 [{_, one} | _tail] = [one: 1, two: 2, three: 3, four: 4]

--- a/reading/lists.livemd
+++ b/reading/lists.livemd
@@ -259,7 +259,7 @@ flowchart LR
 Bind `1` in the following list to a variable `a` using pattern matching.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 [a, _b, _c] = [1, 2, 3]
@@ -276,7 +276,7 @@ Enter your solution below.
 Bind `1` in the following list to a variable `a` using pattern matching.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 [a | _tail] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
@@ -293,7 +293,7 @@ Enter your solution below.
 Bind `1` and `2`, and `3` in the following list to variables `a`, `b`, and `c` using pattern matching.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 [a, b, c | _tail] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]

--- a/reading/maps.livemd
+++ b/reading/maps.livemd
@@ -147,7 +147,7 @@ map[:key]
 In the Elixir cell below, access the `:hello` key in `map`. Retrieve the value using both **map[key]** and **map.key** notation.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 **map.key** notation.
 
@@ -216,7 +216,7 @@ Use a map to represent a todo item The todo map should have `:title` and `:compl
 Bind your map to a `todo` variable, and update the value so `completed` is `true`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 todo = %{title: "finish maps exercise", completed: false}
@@ -295,7 +295,7 @@ We might use this to confirm our map matches some shape.
 Bind `2` and `4` in the following map to variables `two` and `four`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 %{two: two, four: four} = %{one: 1, two: 2, three: 3, four: 4}

--- a/reading/match_operator.livemd
+++ b/reading/match_operator.livemd
@@ -160,7 +160,7 @@ you're using an unbound variable.
 In the Elixir cell below, create a variable `hello` and bind it to the value `"world"`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 hello = "world".

--- a/reading/modules.livemd
+++ b/reading/modules.livemd
@@ -94,7 +94,7 @@ Greeter.hi("Peter Parker")
 Create a `Math` module with an `add/2` function that adds two numbers together.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 defmodule Math do
@@ -155,7 +155,7 @@ gogo("necktie")
 Add an `arms/0` function to the `InspectorGadget` module above that calls `gogo("arms")`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 defmodule InspectorGadget do
@@ -324,7 +324,7 @@ Languages.English.greeting()
 Create a submodule under the `Languages` module with a `greeting/0` function that returns a greeting in another language. You may choose the language and the name of the submodule.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 defmodule Languages.Spanish do
@@ -514,7 +514,7 @@ Math.add(1, 2, 3) # 6
 ```
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 defmodule Math do

--- a/reading/non_enumerables.livemd
+++ b/reading/non_enumerables.livemd
@@ -167,7 +167,7 @@ joined_string = Enum.join(transformed_list)
 Start with a string such as `"hello"`. Use enumeration to double every character in the string so the `"hello"` would become `"hheelllloo"`.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Possible Solution</summary>
+<summary>Example Solution</summary>
 
 ```elixir
 split_string = String.split("hello", "")

--- a/reading/pattern_matching.livemd
+++ b/reading/pattern_matching.livemd
@@ -106,8 +106,9 @@ Remember that you can use the `[head | tail]` syntax with a list.
 
 Replace `nil` with your pattern match statement.
 
-<details>
-<summary>Hint</summary>
+
+<details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
+<summary>Example solution</summary>
 <code>[one, two, three | tail] = list</code>
 </details>
 

--- a/reading/ranges.livemd
+++ b/reading/ranges.livemd
@@ -105,7 +105,7 @@ Enum.to_list(0..10//2)
 In the Elixir cell below, use [Enum.to_list/1](https://hexdocs.pm/elixir/Enum.html#to_list/1) to convert a range from `3` to `9` with a step of `3` into a list.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-  <summary>Hint</summary>
+  <summary>Example solution</summary>
 
   ```elixir
   Enum.to_list(3..9//3)

--- a/reading/scripts.livemd
+++ b/reading/scripts.livemd
@@ -135,7 +135,7 @@ However, we have a bug. The `answer` is re-bound every time we recursively call 
 Modify the `guessing_game.ex` script so that the random `answer` does not change each time the player guesses
 a number.
 
-<details>
+<details style="background-color: burlywood; padding: 1rem; margin: 1rem 0;">
 <summary>Hint</summary>
 Consider using module attributes, which are created at compile time and will not change.
 </details>

--- a/reading/strings.livemd
+++ b/reading/strings.livemd
@@ -90,7 +90,7 @@ So `"Peter"` would be come `"Hi Peter."`.
 Replace `nil` with your answer.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 "Hi " <> "Peter."
@@ -130,7 +130,7 @@ Notice that there's a grammar mistake below that could easily be missed when usi
 In the Elixir cell below, use **string interpolation** to say `I have #{X - 1} classmates.`. Where X is the number of people in your cohort including yourself.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 "I have #{1 - 1} classmates."

--- a/reading/structs.livemd
+++ b/reading/structs.livemd
@@ -137,7 +137,7 @@ end
 Define a `Coordinate` struct which must have `:x` and `:y` keys.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 defmodule Coordinate do
@@ -205,7 +205,7 @@ Hero.reveal(hero) # "I am Peter Parker."
 ```
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 defmodule Hero do

--- a/reading/tuples.livemd
+++ b/reading/tuples.livemd
@@ -52,7 +52,7 @@ In the Elixir cell below, create a tuple with `:ok` as the first element, and `"
 the second element.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 {:ok, "got it!"}
@@ -131,7 +131,7 @@ Use pattern matching to bind `"jewel"` to a variable called `jewel`.
 Replace `jewel` with your answer.
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
-<summary>Hint</summary>
+<summary>Example solution</summary>
 
 ```elixir
 {_gold, _treasure, jewel} = {"gold", "treasure", "jewel"}


### PR DESCRIPTION
Fixes #467

@BrooklinJazz feel free to drop the dedicated background-color for `hint`s, I just figured it may be nice to have a visual cue for users:)



