### PR TITLE
fix Tic-Tac-Toe test

### DIFF
--- a/exercises/tic-tac-toe.livemd
+++ b/exercises/tic-tac-toe.livemd
@@ -164,8 +164,8 @@ defmodule TicTacToe do
   Filling an empty board.
 
   iex> board = [[nil, nil, nil], [nil, nil, nil], [nil, nil, nil]]
-  iex> TicTacToe.fill(board, {0, 0}, "X")
-  [[nil, nil, nil], [nil, nil, nil], [nil, nil, "X"]]
+  iex> TicTacToe.fill(board, {1, 0}, "X")
+  [[nil, nil, nil], [nil, nil, nil], [nil, "X", nil]]
   iex> TicTacToe.fill(board, {1, 1}, "O")
   [[nil, nil, nil], [nil, "O", nil], [nil, nil, nil]]
   iex> TicTacToe.fill(board, {2, 2}, "X")

--- a/reading/pattern_matching.livemd
+++ b/reading/pattern_matching.livemd
@@ -113,8 +113,6 @@ defmodule Hello do
 end
 ```
 
-
-
 Enter your solution below.
 
 ```elixir


### PR DESCRIPTION
Fixed the first test for the Tic-Tac-Toe fill function. 
- Corrected expected result 
- Change the {x, y} coordinates to be not identical. If the student mistakenly interchanges x and y values in their code, this test will not pass. 