### PR TITLE
typo fix in safe range exercise

### DIFF
--- a/exercises/saferange.livemd
+++ b/exercises/saferange.livemd
@@ -19,6 +19,8 @@ Mix.install([
 In the lesson on creating a range of numbers using the `..`
 operator:
 
+<!-- livebook:{"force_markdown":true} -->
+
 ```elixir
 iex> Enum.to_list(1..5)
 [1, 2, 3, 4, 5]
@@ -26,6 +28,8 @@ iex> Enum.to_list(1..5)
 
 You also learned that it can optionally take a
 *step* value:
+
+<!-- livebook:{"force_markdown":true} -->
 
 ```elixir
 iex> Enum.to_list(1..5//2)
@@ -41,8 +45,11 @@ But, what happens when the *step* attempts to create a
 sequence that is not incrementing towards the *last*
 number, such as:
 
+<!-- livebook:{"force_markdown":true} -->
+
 ```elixir
 iex> Enum.to_list(1..5//-1)
+[]
 ```
 
 In this case, an empty list (`[]`) is returned as there
@@ -71,6 +78,8 @@ The [Enum](https://hexdocs.pm/elixir/Enum.html) module provides two functions to
 from a list (`[]`) at a given index. The difference is in how
 they behave when the index is invalid; ex:
 
+<!-- livebook:{"force_markdown":true} -->
+
 ```elixir
 iex> list = [1, 2, 3, 4, 5]
 [1, 2, 3, 4, 5]
@@ -89,6 +98,8 @@ iex> Enum.fetch!(list, 10)
 When accessing a Map (`%{}`) with a *key*, the [Map](https://hexdocs.pm/elixir/Map.html) module
 provides these two functions. The difference is in how they
 behave when the *key* is **not** present in the map; ex:
+
+<!-- livebook:{"force_markdown":true} -->
 
 ```elixir
 iex> map = %{a: 1, b: 2}
@@ -113,6 +124,8 @@ functions called `range` and `range!` where:
 In Elixir exceptions may be thrown using the `raise` function,
 for example here is how to throw a [RuntimeError](https://hexdocs.pm/elixir/RuntimeError.html) exception:
 
+<!-- livebook:{"force_markdown":true} -->
+
 ```elixir
 iex> raise "Houston, we have a problem."
 ** (RuntimeError) Houston, we have a problem.
@@ -120,7 +133,6 @@ iex> raise "Houston, we have a problem."
 
 ```elixir
 defmodule SafeRange do
-
   @doc """
   Generate a sequences of integers from 'first' to 'last' with an
   option 'step' value.
@@ -170,7 +182,6 @@ defmodule SafeRange do
   """
   def range!(first, last, step \\ DEFAULT) do
   end
-
 end
 ```
 


### PR DESCRIPTION
I believe the original intention was to show the output of the elixir shell but not present the shell with `iex>` typed in. I could be wrong though.