### PR TITLE
Allow for custom capitalizations in navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Enumeration 2
 Built-in Modules
 Reduce
 Dates and Time
-Pattern Matching
+Advanced Pattern Matching
 Guards
 String Manipulation
 Protocols

--- a/exercises/battle_map.livemd
+++ b/exercises/battle_map.livemd
@@ -140,6 +140,6 @@ $ git commit -m "finish battle map exercise"
 
 ## Up Next
 
-| Previous                                           | Next                                                               |
-| -------------------------------------------------- | -----------------------------------------------------------------: |
-| [Rpg Abilities](../exercises/rpg_abilities.livemd) | [Filter Values By Type](../exercises/filter_values_by_type.livemd) |
+| Previous                                     | Next                                                       |
+| -------------------------------------------- | ---------------------------------------------------------: |
+| [Classified](../exercises/classified.livemd) | [Pokemon Protocols](../exercises/pokemon_protocols.livemd) |

--- a/exercises/capstone_project_mock.livemd
+++ b/exercises/capstone_project_mock.livemd
@@ -58,4 +58,4 @@ $ git commit -m "finish capstone project mock exercise"
 
 | Previous                                             | Next                                   |
 | ---------------------------------------------------- | -------------------------------------: |
-| [Portfolio Mock](../exercises/portfolio_mock.livemd) | [Liveview](../reading/liveview.livemd) |
+| [Portfolio Mock](../exercises/portfolio_mock.livemd) | [LiveView](../reading/liveview.livemd) |

--- a/exercises/classified.livemd
+++ b/exercises/classified.livemd
@@ -73,6 +73,6 @@ $ git commit -m "finish classified exercise"
 
 ## Up Next
 
-| Previous                                                         | Next                                               |
-| ---------------------------------------------------------------- | -------------------------------------------------: |
-| [Phone Number Parsing](../exercises/phone_number_parsing.livemd) | [Rpg Abilities](../exercises/rpg_abilities.livemd) |
+| Previous                                                       | Next                                         |
+| -------------------------------------------------------------- | -------------------------------------------: |
+| [Currency Conversion](../exercises/currency_conversion.livemd) | [Battle Map](../exercises/battle_map.livemd) |

--- a/exercises/consumable_protocol.livemd
+++ b/exercises/consumable_protocol.livemd
@@ -193,6 +193,6 @@ $ git commit -m "finish consumable protocol exercise"
 
 ## Up Next
 
-| Previous                                     | Next                                         |
-| -------------------------------------------- | -------------------------------------------: |
-| [Classified](../exercises/classified.livemd) | [Battle Map](../exercises/battle_map.livemd) |
+| Previous                                                       | Next                                 |
+| -------------------------------------------------------------- | -----------------------------------: |
+| [Math With Protocols](../exercises/math_with_protocols.livemd) | [Scripts](../reading/scripts.livemd) |

--- a/exercises/currency_conversion.livemd
+++ b/exercises/currency_conversion.livemd
@@ -107,6 +107,6 @@ $ git commit -m "finish currency conversion exercise"
 
 ## Up Next
 
-| Previous                                           | Next                                                             |
-| -------------------------------------------------- | ---------------------------------------------------------------: |
-| [Number Wordle](../exercises/number_wordle.livemd) | [Phone Number Parsing](../exercises/phone_number_parsing.livemd) |
+| Previous                                           | Next                                         |
+| -------------------------------------------------- | -------------------------------------------: |
+| [Number Wordle](../exercises/number_wordle.livemd) | [Classified](../exercises/classified.livemd) |

--- a/exercises/custom_enum_with_reduce.livemd
+++ b/exercises/custom_enum_with_reduce.livemd
@@ -152,4 +152,4 @@ $ git commit -m "finish custom enum with reduce exercise"
 
 | Previous                                               | Next                                   |
 | ------------------------------------------------------ | -------------------------------------: |
-| [Weighted Voting](../exercises/weighted_voting.livemd) | [Datetime](../reading/datetime.livemd) |
+| [Weighted Voting](../exercises/weighted_voting.livemd) | [DateTime](../reading/datetime.livemd) |

--- a/exercises/fibonacci.livemd
+++ b/exercises/fibonacci.livemd
@@ -98,4 +98,4 @@ $ git commit -m "finish fibonacci exercise"
 
 | Previous                                                                   | Next                                                     |
 | -------------------------------------------------------------------------- | -------------------------------------------------------: |
-| [Maps Mapsets Keyword Lists](../reading/maps_mapsets_keyword_lists.livemd) | [Pascals Triangle](../exercises/pascals_triangle.livemd) |
+| [Maps MapSets Keyword Lists](../reading/maps_mapsets_keyword_lists.livemd) | [Pascals Triangle](../exercises/pascals_triangle.livemd) |

--- a/exercises/filter_values_by_type.livemd
+++ b/exercises/filter_values_by_type.livemd
@@ -164,6 +164,6 @@ $ git commit -m "finish filter values by type exercise"
 
 ## Up Next
 
-| Previous                                     | Next                               |
-| -------------------------------------------- | ---------------------------------: |
-| [Battle Map](../exercises/battle_map.livemd) | [Reduce](../reading/reduce.livemd) |
+| Previous                                                   | Next                               |
+| ---------------------------------------------------------- | ---------------------------------: |
+| [Pokemon Protocols](../exercises/pokemon_protocols.livemd) | [Reduce](../reading/reduce.livemd) |

--- a/exercises/games_guessing_game.livemd
+++ b/exercises/games_guessing_game.livemd
@@ -91,7 +91,7 @@ Run the following in your command line from the beta_curriculum folder to track 
 
 ```
 $ git add .
-$ git commit -m "finish games rock paper scissors exercise"
+$ git commit -m "finish games guessing game exercise"
 ```
 
 ## Up Next

--- a/exercises/games_rock_paper_scissors.livemd
+++ b/exercises/games_rock_paper_scissors.livemd
@@ -67,4 +67,4 @@ $ git commit -m "finish games rock paper scissors exercise"
 
 | Previous                                                       | Next                               |
 | -------------------------------------------------------------- | ---------------------------------: |
-| [Games Guessing Game](../exercises/games_guessing_game.livemd) | [Exunit](../reading/exunit.livemd) |
+| [Games Guessing Game](../exercises/games_guessing_game.livemd) | [ExUnit](../reading/exunit.livemd) |

--- a/exercises/games_setup.livemd
+++ b/exercises/games_setup.livemd
@@ -40,11 +40,11 @@ Run the following in your command line from the beta_curriculum folder to track 
 
 ```
 $ git add .
-$ git commit -m "finish games rock paper scissors exercise"
+$ git commit -m "finish games setup exercise"
 ```
 
 ## Up Next
 
 | Previous                   | Next                                                           |
 | -------------------------- | -------------------------------------------------------------: |
-| [Io](../reading/io.livemd) | [Games Guessing Game](../exercises/games_guessing_game.livemd) |
+| [IO](../reading/io.livemd) | [Games Guessing Game](../exercises/games_guessing_game.livemd) |

--- a/exercises/home_page.livemd
+++ b/exercises/home_page.livemd
@@ -75,4 +75,4 @@ $ git commit -m "finish home page exercise"
 
 | Previous                               | Next                           |
 | -------------------------------------- | -----------------------------: |
-| [Html Css](../reading/html_css.livemd) | [Apis](../reading/apis.livemd) |
+| [HTML CSS](../reading/html_css.livemd) | [APIs](../reading/apis.livemd) |

--- a/exercises/inventory_management.livemd
+++ b/exercises/inventory_management.livemd
@@ -73,4 +73,4 @@ $ git commit -m "finish inventory management exercise"
 
 | Previous                                                 | Next                                           |
 | -------------------------------------------------------- | ---------------------------------------------: |
-| [Caching Agent Ets](../reading/caching_agent_ets.livemd) | [Smart Cache](../exercises/smart_cache.livemd) |
+| [Caching Agent ETS](../reading/caching_agent_ets.livemd) | [Smart Cache](../exercises/smart_cache.livemd) |

--- a/exercises/journal_cli.livemd
+++ b/exercises/journal_cli.livemd
@@ -289,6 +289,6 @@ $ git commit -m "finish journal cli exercise"
 
 ## Up Next
 
-| Previous                                             | Next                         |
-| ---------------------------------------------------- | ---------------------------: |
-| [Snowman Script](../exercises/snowman_script.livemd) | [Iex](../reading/iex.livemd) |
+| Previous                                             | Next                                                 |
+| ---------------------------------------------------- | ---------------------------------------------------: |
+| [Snowman Script](../exercises/snowman_script.livemd) | [Metaprogramming](../reading/metaprogramming.livemd) |

--- a/exercises/kitchen_queue.livemd
+++ b/exercises/kitchen_queue.livemd
@@ -122,4 +122,4 @@ $ git commit -m "finish kitchen queue exercise"
 
 | Previous                                                                       | Next                                   |
 | ------------------------------------------------------------------------------ | -------------------------------------: |
-| [Concurrent Image Processing](../exercises/concurrent_image_processing.livemd) | [Html Css](../reading/html_css.livemd) |
+| [Concurrent Image Processing](../exercises/concurrent_image_processing.livemd) | [HTML CSS](../reading/html_css.livemd) |

--- a/exercises/math_with_guards.livemd
+++ b/exercises/math_with_guards.livemd
@@ -172,11 +172,11 @@ Run the following in your command line from the beta_curriculum folder to track 
 
 ```
 $ git add .
-$ git commit -m "finish math exercise"
+$ git commit -m "finish math with guards exercise"
 ```
 
 ## Up Next
 
 | Previous                                                     | Next                                         |
 | ------------------------------------------------------------ | -------------------------------------------: |
-| [Message Validation](../exercises/message_validation.livemd) | [Rps Guards](../exercises/rps_guards.livemd) |
+| [Message Validation](../exercises/message_validation.livemd) | [RPS Guards](../exercises/rps_guards.livemd) |

--- a/exercises/math_with_protocols.livemd
+++ b/exercises/math_with_protocols.livemd
@@ -160,11 +160,11 @@ Run the following in your command line from the beta_curriculum folder to track 
 
 ```
 $ git add .
-$ git commit -m "finish math exercise"
+$ git commit -m "finish math with protocols exercise"
 ```
 
 ## Up Next
 
-| Previous                                 | Next                                                       |
-| ---------------------------------------- | ---------------------------------------------------------: |
-| [Protocols](../reading/protocols.livemd) | [Pokemon Protocols](../exercises/pokemon_protocols.livemd) |
+| Previous                                 | Next                                                           |
+| ---------------------------------------- | -------------------------------------------------------------: |
+| [Protocols](../reading/protocols.livemd) | [Consumable Protocol](../exercises/consumable_protocol.livemd) |

--- a/exercises/measurements.livemd
+++ b/exercises/measurements.livemd
@@ -131,4 +131,4 @@ $ git commit -m "finish measurements exercise"
 
 | Previous                                             | Next                                       |
 | ---------------------------------------------------- | -----------------------------------------: |
-| [Counting Votes](../exercises/counting_votes.livemd) | [Saferange](../exercises/saferange.livemd) |
+| [Counting Votes](../exercises/counting_votes.livemd) | [SafeRange](../exercises/saferange.livemd) |

--- a/exercises/metric_conversion.livemd
+++ b/exercises/metric_conversion.livemd
@@ -114,4 +114,4 @@ $ git commit -m "finish metric conversion exercise"
 
 | Previous                                                         | Next                               |
 | ---------------------------------------------------------------- | ---------------------------------: |
-| [Rps Pattern Matching](../exercises/rps_pattern_matching.livemd) | [Guards](../reading/guards.livemd) |
+| [RPS Pattern Matching](../exercises/rps_pattern_matching.livemd) | [Guards](../reading/guards.livemd) |

--- a/exercises/named_number_lists.livemd
+++ b/exercises/named_number_lists.livemd
@@ -91,4 +91,4 @@ $ git commit -m "finish named number lists exercise"
 
 | Previous                                 | Next                                                 |
 | ---------------------------------------- | ---------------------------------------------------: |
-| [Fizzbuzz](../exercises/fizzbuzz.livemd) | [Counting Votes](../exercises/counting_votes.livemd) |
+| [FizzBuzz](../exercises/fizzbuzz.livemd) | [Counting Votes](../exercises/counting_votes.livemd) |

--- a/exercises/phone_number_parsing.livemd
+++ b/exercises/phone_number_parsing.livemd
@@ -128,6 +128,6 @@ $ git commit -m "finish phone number parsing exercise"
 
 ## Up Next
 
-| Previous                                                       | Next                                         |
-| -------------------------------------------------------------- | -------------------------------------------: |
-| [Currency Conversion](../exercises/currency_conversion.livemd) | [Classified](../exercises/classified.livemd) |
+| Previous                                                         | Next                                     |
+| ---------------------------------------------------------------- | ---------------------------------------: |
+| [Rollable Expressions](../exercises/rollable_expressions.livemd) | [Protocols](../reading/protocols.livemd) |

--- a/exercises/pokemon_api.livemd
+++ b/exercises/pokemon_api.livemd
@@ -79,4 +79,4 @@ $ git commit -m "finish pokemon api exercise"
 
 | Previous                                                             | Next                                         |
 | -------------------------------------------------------------------- | -------------------------------------------: |
-| [Spoonacular Recipe Api](../exercises/spoonacular_recipe_api.livemd) | [Web Servers](../reading/web_servers.livemd) |
+| [Spoonacular Recipe API](../exercises/spoonacular_recipe_api.livemd) | [Web Servers](../reading/web_servers.livemd) |

--- a/exercises/pokemon_battle.livemd
+++ b/exercises/pokemon_battle.livemd
@@ -183,4 +183,4 @@ $ git commit -m "finish pokemon battle exercise"
 
 | Previous                                         | Next                               |
 | ------------------------------------------------ | ---------------------------------: |
-| [Rpg Dialogue](../exercises/rpg_dialogue.livemd) | [Ranges](../reading/ranges.livemd) |
+| [RPG Dialogue](../exercises/rpg_dialogue.livemd) | [Ranges](../reading/ranges.livemd) |

--- a/exercises/pokemon_protocols.livemd
+++ b/exercises/pokemon_protocols.livemd
@@ -132,6 +132,6 @@ $ git commit -m "finish pokemon protocols exercise"
 
 ## Up Next
 
-| Previous                                                       | Next                                 |
-| -------------------------------------------------------------- | -----------------------------------: |
-| [Math With Protocols](../exercises/math_with_protocols.livemd) | [Scripts](../reading/scripts.livemd) |
+| Previous                                     | Next                                                               |
+| -------------------------------------------- | -----------------------------------------------------------------: |
+| [Battle Map](../exercises/battle_map.livemd) | [Filter Values By Type](../exercises/filter_values_by_type.livemd) |

--- a/exercises/pokemon_server.livemd
+++ b/exercises/pokemon_server.livemd
@@ -132,11 +132,11 @@ Enter your solution below.
 defmodule Pokemon do
   @moduledoc """
   Pokemon Server
-  
+
   Defines a Pokemon GenServer and struct.
-  
+
   ## Examples
-  
+
     iex> %Pokemon{name: "Charmander", type: :fire}
     %Pokemon{name: "Charmander", type: :fire, health: 20, attack: 5}
   """
@@ -144,7 +144,7 @@ defmodule Pokemon do
 
   @doc """
   Start the Pokemon GenServer.
-  
+
   ## Examples
       iex> {:ok, pokemon} = Pokemon.start_link([pokemon: %Pokemon{name: "Charmander", type: :fire}])
   """
@@ -158,9 +158,9 @@ defmodule Pokemon do
 
   @doc """
   Apply the attacker's attack damage to the defender's health.
-  
+
   ## Examples
-  
+
     With default values.
     iex> {:ok, attacker} = Pokemon.start_link(pokemon: %Pokemon{name: "Bulbasaur1", type: :grass})
     iex> {:ok, defender} = Pokemon.start_link(pokemon: %Pokemon{name: "Bulbasaur2", type: :grass})
@@ -174,9 +174,9 @@ defmodule Pokemon do
     %Pokemon{name: "Bulbasaur2", type: :grass, health: 0, attack: 5}
     iex> Pokemon.attack(attacker, defender)
     %Pokemon{name: "Bulbasaur2", type: :grass, health: 0, attack: 5}
-  
+
     Ensure you use the attacking pokemon's attack number to apply damage to the defending pokemon's health.
-  
+
     iex> {:ok, attacker} = Pokemon.start_link(pokemon: %Pokemon{name: "Bulbasaur1", type: :grass, attack: 20})
     iex> {:ok, defender} = Pokemon.start_link(pokemon: %Pokemon{name: "Bulbasaur2", type: :grass, health: 45})
     iex> Pokemon.attack(attacker, defender)
@@ -222,4 +222,4 @@ $ git commit -m "finish pokemon server exercise"
 
 | Previous                                                                           | Next                           |
 | ---------------------------------------------------------------------------------- | -----------------------------: |
-| [Rock Paper Scissors Genserver](../exercises/rock_paper_scissors_genserver.livemd) | [Task](../reading/task.livemd) |
+| [Rock Paper Scissors GenServer](../exercises/rock_paper_scissors_genserver.livemd) | [Task](../reading/task.livemd) |

--- a/exercises/portfolio_mock.livemd
+++ b/exercises/portfolio_mock.livemd
@@ -59,4 +59,4 @@ $ git commit -m "finish portfolio mock exercise"
 
 | Previous                                                               | Next                                                               |
 | ---------------------------------------------------------------------- | -----------------------------------------------------------------: |
-| [Tailwind Css Components](../exercises/tailwind_css_components.livemd) | [Capstone Project Mock](../exercises/capstone_project_mock.livemd) |
+| [Tailwind CSS Components](../exercises/tailwind_css_components.livemd) | [Capstone Project Mock](../exercises/capstone_project_mock.livemd) |

--- a/exercises/public_chat_api.livemd
+++ b/exercises/public_chat_api.livemd
@@ -48,4 +48,4 @@ $ git commit -m "finish public chat api exercise"
 
 | Previous                       | Next                                                                 |
 | ------------------------------ | -------------------------------------------------------------------: |
-| [Apis](../reading/apis.livemd) | [Spoonacular Recipe Api](../exercises/spoonacular_recipe_api.livemd) |
+| [APIs](../reading/apis.livemd) | [Spoonacular Recipe API](../exercises/spoonacular_recipe_api.livemd) |

--- a/exercises/rock_paper_scissors_lizard_spock.livemd
+++ b/exercises/rock_paper_scissors_lizard_spock.livemd
@@ -115,4 +115,4 @@ $ git commit -m "finish rock paper scissors lizard spock exercise"
 
 | Previous                             | Next                                             |
 | ------------------------------------ | -----------------------------------------------: |
-| [Structs](../reading/structs.livemd) | [Rpg Dialogue](../exercises/rpg_dialogue.livemd) |
+| [Structs](../reading/structs.livemd) | [RPG Dialogue](../exercises/rpg_dialogue.livemd) |

--- a/exercises/rollable_expressions.livemd
+++ b/exercises/rollable_expressions.livemd
@@ -160,6 +160,6 @@ $ git commit -m "finish rollable expressions exercise"
 
 ## Up Next
 
-| Previous                                           | Next                                     |
-| -------------------------------------------------- | ---------------------------------------: |
-| [Caesar Cypher](../exercises/caesar_cypher.livemd) | [Protocols](../reading/protocols.livemd) |
+| Previous                                           | Next                                                             |
+| -------------------------------------------------- | ---------------------------------------------------------------: |
+| [Caesar Cypher](../exercises/caesar_cypher.livemd) | [Phone Number Parsing](../exercises/phone_number_parsing.livemd) |

--- a/exercises/rps_guards.livemd
+++ b/exercises/rps_guards.livemd
@@ -103,7 +103,7 @@ Run the following in your command line from the beta_curriculum folder to track 
 
 ```
 $ git add .
-$ git commit -m "finish rps pattern matching exercise"
+$ git commit -m "finish rps guards exercise"
 ```
 
 ## Up Next

--- a/exercises/rubber_ducky.livemd
+++ b/exercises/rubber_ducky.livemd
@@ -75,4 +75,4 @@ $ git commit -m "finish rubber ducky exercise"
 
 | Previous                               | Next                                                                         |
 | -------------------------------------- | ---------------------------------------------------------------------------: |
-| [Liveview](../reading/liveview.livemd) | [Portfolio Blog Live Search](../exercises/portfolio_blog_live_search.livemd) |
+| [LiveView](../reading/liveview.livemd) | [Portfolio Blog Live Search](../exercises/portfolio_blog_live_search.livemd) |

--- a/exercises/saferange.livemd
+++ b/exercises/saferange.livemd
@@ -20,7 +20,7 @@ In the lesson on creating a range of numbers using the `..`
 operator:
 
 ```elixir
-iex> Enum.to_list(1..5)
+iex > Enum.to_list(1..5)
 [1, 2, 3, 4, 5]
 ```
 
@@ -28,7 +28,7 @@ You also learned that it can optionally take a
 *step* value:
 
 ```elixir
-iex> Enum.to_list(1..5//2)
+iex > Enum.to_list(1..5//2)
 [1, 3, 5]
 ```
 
@@ -42,7 +42,7 @@ sequence that is not incrementing towards the *last*
 number, such as:
 
 ```elixir
-iex> Enum.to_list(1..5//-1)
+iex > Enum.to_list(1..5//-1)
 ```
 
 In this case, an empty list (`[]`) is returned as there
@@ -120,7 +120,6 @@ iex> raise "Houston, we have a problem."
 
 ```elixir
 defmodule SafeRange do
-
   @doc """
   Generate a sequences of integers from 'first' to 'last' with an
   option 'step' value.
@@ -170,7 +169,6 @@ defmodule SafeRange do
   """
   def range!(first, last, step \\ DEFAULT) do
   end
-
 end
 ```
 

--- a/exercises/snowman_script.livemd
+++ b/exercises/snowman_script.livemd
@@ -105,4 +105,4 @@ $ git commit -m "finish snowman script exercise"
 
 | Previous                             | Next                                           |
 | ------------------------------------ | ---------------------------------------------: |
-| [Scripts](../reading/scripts.livemd) | [Journal Cli](../exercises/journal_cli.livemd) |
+| [Scripts](../reading/scripts.livemd) | [Journal CLI](../exercises/journal_cli.livemd) |

--- a/exercises/spoonacular_recipe_api.livemd
+++ b/exercises/spoonacular_recipe_api.livemd
@@ -46,4 +46,4 @@ $ git commit -m "finish spoonacular recipe api exercise"
 
 | Previous                                               | Next                                           |
 | ------------------------------------------------------ | ---------------------------------------------: |
-| [Public Chat Api](../exercises/public_chat_api.livemd) | [Pokemon Api](../exercises/pokemon_api.livemd) |
+| [Public Chat API](../exercises/public_chat_api.livemd) | [Pokemon API](../exercises/pokemon_api.livemd) |

--- a/exercises/stack.livemd
+++ b/exercises/stack.livemd
@@ -57,6 +57,6 @@ $ git commit -m "finish stack exercise"
 
 ## Up Next
 
-| Previous                                                   | Next                                                   |
-| ---------------------------------------------------------- | -----------------------------------------------------: |
-| [Testing Genservers](../reading/testing_genservers.livemd) | [Product Filters](../exercises/product_filters.livemd) |
+| Previous                                                                                 | Next                                                   |
+| ---------------------------------------------------------------------------------------- | -----------------------------------------------------: |
+| [Documentation And Static Analysis](../reading/documentation_and_static_analysis.livemd) | [Product Filters](../exercises/product_filters.livemd) |

--- a/exercises/tailwind_css_components.livemd
+++ b/exercises/tailwind_css_components.livemd
@@ -85,4 +85,4 @@ $ git commit -m "finish tailwind css components exercise"
 
 | Previous                                       | Next                                                 |
 | ---------------------------------------------- | ---------------------------------------------------: |
-| [Tailwind Css](../reading/tailwind_css.livemd) | [Portfolio Mock](../exercises/portfolio_mock.livemd) |
+| [Tailwind CSS](../reading/tailwind_css.livemd) | [Portfolio Mock](../exercises/portfolio_mock.livemd) |

--- a/exercises/tic-tac-toe.livemd
+++ b/exercises/tic-tac-toe.livemd
@@ -325,9 +325,3 @@ Run the following in your command line from the beta_curriculum folder to track 
 $ git add .
 $ git commit -m "finish tic-tac-toe exercise"
 ```
-
-## Up Next
-
-| Previous                                                           | Next                               |
-| ------------------------------------------------------------------ | ---------------------------------: |
-| [Filter Values By Type](../exercises/filter_values_by_type.livemd) | [Reduce](../reading/reduce.livemd) |

--- a/exercises/time_converting.livemd
+++ b/exercises/time_converting.livemd
@@ -113,4 +113,4 @@ $ git commit -m "finish time converting exercise"
 
 | Previous                               | Next                                       |
 | -------------------------------------- | -----------------------------------------: |
-| [Datetime](../reading/datetime.livemd) | [Itinerary](../exercises/itinerary.livemd) |
+| [DateTime](../reading/datetime.livemd) | [Itinerary](../exercises/itinerary.livemd) |

--- a/exercises/traffic_light_server.livemd
+++ b/exercises/traffic_light_server.livemd
@@ -445,4 +445,4 @@ $ git commit -m "finish traffic light server exercise"
 
 | Previous                                           | Next                                                                               |
 | -------------------------------------------------- | ---------------------------------------------------------------------------------: |
-| [Generic Server](../reading/generic_server.livemd) | [Rock Paper Scissors Genserver](../exercises/rock_paper_scissors_genserver.livemd) |
+| [Generic Server](../reading/generic_server.livemd) | [Rock Paper Scissors GenServer](../exercises/rock_paper_scissors_genserver.livemd) |

--- a/exercises/treasure_matching.livemd
+++ b/exercises/treasure_matching.livemd
@@ -115,4 +115,4 @@ $ git commit -m "finish treasure matching exercise"
 
 | Previous                                                                 | Next                                                             |
 | ------------------------------------------------------------------------ | ---------------------------------------------------------------: |
-| [Advanced Pattern Matching](../reading/advanced_pattern_matching.livemd) | [Rps Pattern Matching](../exercises/rps_pattern_matching.livemd) |
+| [Advanced Pattern Matching](../reading/advanced_pattern_matching.livemd) | [RPS Pattern Matching](../exercises/rps_pattern_matching.livemd) |

--- a/exercises/typing_game.livemd
+++ b/exercises/typing_game.livemd
@@ -117,4 +117,4 @@ $ git commit -m "finish typing game exercise"
 
 | Previous                                                 | Next                             |
 | -------------------------------------------------------- | -------------------------------: |
-| [Creature Spawner](../exercises/creature_spawner.livemd) | [Rdbms](../reading/rdbms.livemd) |
+| [Creature Spawner](../exercises/creature_spawner.livemd) | [RDBMS](../reading/rdbms.livemd) |

--- a/reading/advanced_pattern_matching.livemd
+++ b/reading/advanced_pattern_matching.livemd
@@ -365,7 +365,7 @@ Run the following in your command line from the beta_curriculum folder to track 
 
 ```
 $ git add .
-$ git commit -m "finish pattern matching section"
+$ git commit -m "finish advanced pattern matching section"
 ```
 
 ## Up Next

--- a/reading/apis.livemd
+++ b/reading/apis.livemd
@@ -253,4 +253,4 @@ $ git commit -m "finish apis section"
 
 | Previous                                   | Next                                                   |
 | ------------------------------------------ | -----------------------------------------------------: |
-| [Home Page](../exercises/home_page.livemd) | [Public Chat Api](../exercises/public_chat_api.livemd) |
+| [Home Page](../exercises/home_page.livemd) | [Public Chat API](../exercises/public_chat_api.livemd) |

--- a/reading/book_search_book_content.livemd
+++ b/reading/book_search_book_content.livemd
@@ -797,4 +797,4 @@ $ git commit -m "finish book search book content section"
 
 | Previous                                             | Next                                           |
 | ---------------------------------------------------- | ---------------------------------------------: |
-| [Portfolio Tags](../exercises/portfolio_tags.livemd) | [Tailwind Css](../reading/tailwind_css.livemd) |
+| [Portfolio Tags](../exercises/portfolio_tags.livemd) | [Tailwind CSS](../reading/tailwind_css.livemd) |

--- a/reading/built-in_modules.livemd
+++ b/reading/built-in_modules.livemd
@@ -981,9 +981,3 @@ Run the following in your command line from the beta_curriculum folder to track 
 $ git add .
 $ git commit -m "finish built-in modules section"
 ```
-
-## Up Next
-
-| Previous                                       | Next                                                               |
-| ---------------------------------------------- | -----------------------------------------------------------------: |
-| [Book Search](../exercises/book_search.livemd) | [Filter Values By Type](../exercises/filter_values_by_type.livemd) |

--- a/reading/documentation_and_static_analysis.livemd
+++ b/reading/documentation_and_static_analysis.livemd
@@ -406,6 +406,6 @@ $ git commit -m "finish documentation and static analysis section"
 
 ## Up Next
 
-| Previous                           | Next                                                 |
-| ---------------------------------- | ---------------------------------------------------: |
-| [Exunit](../reading/exunit.livemd) | [Metaprogramming](../reading/metaprogramming.livemd) |
+| Previous                           | Next                               |
+| ---------------------------------- | ---------------------------------: |
+| [ExUnit](../reading/exunit.livemd) | [Stack](../exercises/stack.livemd) |

--- a/reading/ecto.livemd
+++ b/reading/ecto.livemd
@@ -777,4 +777,4 @@ $ git commit -m "finish ecto section"
 
 | Previous                         | Next                                         |
 | -------------------------------- | -------------------------------------------: |
-| [Rdbms](../reading/rdbms.livemd) | [Rubix Cube](../exercises/rubix_cube.livemd) |
+| [RDBMS](../reading/rdbms.livemd) | [Rubix Cube](../exercises/rubix_cube.livemd) |

--- a/reading/enum.livemd
+++ b/reading/enum.livemd
@@ -638,4 +638,4 @@ $ git commit -m "finish enum section"
 
 | Previous                           | Next                                     |
 | ---------------------------------- | ---------------------------------------: |
-| [Ranges](../reading/ranges.livemd) | [Fizzbuzz](../exercises/fizzbuzz.livemd) |
+| [Ranges](../reading/ranges.livemd) | [FizzBuzz](../exercises/fizzbuzz.livemd) |

--- a/reading/iex.livemd
+++ b/reading/iex.livemd
@@ -293,6 +293,6 @@ $ git commit -m "finish iex section"
 
 ## Up Next
 
-| Previous                                       | Next                         |
-| ---------------------------------------------- | ---------------------------: |
-| [Journal Cli](../exercises/journal_cli.livemd) | [Mix](../reading/mix.livemd) |
+| Previous                                                   | Next                         |
+| ---------------------------------------------------------- | ---------------------------: |
+| [Testing GenServers](../reading/testing_genservers.livemd) | [Mix](../reading/mix.livemd) |

--- a/reading/io.livemd
+++ b/reading/io.livemd
@@ -62,7 +62,7 @@ Run the following in your command line from the beta_curriculum folder to track 
 
 ```
 $ git add .
-$ git commit -m "finish mix section"
+$ git commit -m "finish io section"
 ```
 
 ## Up Next

--- a/reading/lists_vs_tuples.livemd
+++ b/reading/lists_vs_tuples.livemd
@@ -594,4 +594,4 @@ $ git commit -m "finish lists vs tuples section"
 
 | Previous                             | Next                                                                       |
 | ------------------------------------ | -------------------------------------------------------------------------: |
-| [Streams](../reading/streams.livemd) | [Maps Mapsets Keyword Lists](../reading/maps_mapsets_keyword_lists.livemd) |
+| [Streams](../reading/streams.livemd) | [Maps MapSets Keyword Lists](../reading/maps_mapsets_keyword_lists.livemd) |

--- a/reading/metaprogramming.livemd
+++ b/reading/metaprogramming.livemd
@@ -507,6 +507,6 @@ $ git commit -m "finish metaprogramming section"
 
 ## Up Next
 
-| Previous                                                                                 | Next                                                       |
-| ---------------------------------------------------------------------------------------- | ---------------------------------------------------------: |
-| [Documentation And Static Analysis](../reading/documentation_and_static_analysis.livemd) | [Testing Genservers](../reading/testing_genservers.livemd) |
+| Previous                                       | Next                                                       |
+| ---------------------------------------------- | ---------------------------------------------------------: |
+| [Journal CLI](../exercises/journal_cli.livemd) | [Testing GenServers](../reading/testing_genservers.livemd) |

--- a/reading/mix.livemd
+++ b/reading/mix.livemd
@@ -532,4 +532,4 @@ $ git commit -m "finish mix section"
 
 | Previous                     | Next                       |
 | ---------------------------- | -------------------------: |
-| [Iex](../reading/iex.livemd) | [Io](../reading/io.livemd) |
+| [IEx](../reading/iex.livemd) | [IO](../reading/io.livemd) |

--- a/reading/non_enumerables.livemd
+++ b/reading/non_enumerables.livemd
@@ -206,4 +206,4 @@ $ git commit -m "finish non enumerables section"
 
 | Previous                                   | Next                                               |
 | ------------------------------------------ | -------------------------------------------------: |
-| [Saferange](../exercises/saferange.livemd) | [Comprehensions](../reading/comprehensions.livemd) |
+| [SafeRange](../exercises/saferange.livemd) | [Comprehensions](../reading/comprehensions.livemd) |

--- a/reading/protocols.livemd
+++ b/reading/protocols.livemd
@@ -282,4 +282,4 @@ $ git commit -m "finish protocols section"
 
 | Previous                                                         | Next                                                           |
 | ---------------------------------------------------------------- | -------------------------------------------------------------: |
-| [Rollable Expressions](../exercises/rollable_expressions.livemd) | [Math With Protocols](../exercises/math_with_protocols.livemd) |
+| [Phone Number Parsing](../exercises/phone_number_parsing.livemd) | [Math With Protocols](../exercises/math_with_protocols.livemd) |

--- a/reading/scripts.livemd
+++ b/reading/scripts.livemd
@@ -161,6 +161,6 @@ $ git commit -m "finish scripts section"
 
 ## Up Next
 
-| Previous                                                   | Next                                                 |
-| ---------------------------------------------------------- | ---------------------------------------------------: |
-| [Pokemon Protocols](../exercises/pokemon_protocols.livemd) | [Snowman Script](../exercises/snowman_script.livemd) |
+| Previous                                                       | Next                                                 |
+| -------------------------------------------------------------- | ---------------------------------------------------: |
+| [Consumable Protocol](../exercises/consumable_protocol.livemd) | [Snowman Script](../exercises/snowman_script.livemd) |

--- a/reading/strings_and_binaries.livemd
+++ b/reading/strings_and_binaries.livemd
@@ -418,11 +418,11 @@ Run the following in your command line from the beta_curriculum folder to track 
 
 ```
 $ git add .
-$ git commit -m "finish bitstrings section"
+$ git commit -m "finish strings and binaries section"
 ```
 
 ## Up Next
 
 | Previous                                     | Next                             |
 | -------------------------------------------- | -------------------------------: |
-| [Rps Guards](../exercises/rps_guards.livemd) | [Regex](../reading/regex.livemd) |
+| [RPS Guards](../exercises/rps_guards.livemd) | [Regex](../reading/regex.livemd) |

--- a/reading/tailwind_css.livemd
+++ b/reading/tailwind_css.livemd
@@ -534,4 +534,4 @@ $ git commit -m "finish tailwind css section"
 
 | Previous                                                               | Next                                                                   |
 | ---------------------------------------------------------------------- | ---------------------------------------------------------------------: |
-| [Book Search Book Content](../reading/book_search_book_content.livemd) | [Tailwind Css Components](../exercises/tailwind_css_components.livemd) |
+| [Book Search Book Content](../reading/book_search_book_content.livemd) | [Tailwind CSS Components](../exercises/tailwind_css_components.livemd) |

--- a/reading/task.livemd
+++ b/reading/task.livemd
@@ -249,4 +249,4 @@ $ git commit -m "finish task section"
 
 | Previous                                             | Next                                                     |
 | ---------------------------------------------------- | -------------------------------------------------------: |
-| [Pokemon Server](../exercises/pokemon_server.livemd) | [Caching Agent Ets](../reading/caching_agent_ets.livemd) |
+| [Pokemon Server](../exercises/pokemon_server.livemd) | [Caching Agent ETS](../reading/caching_agent_ets.livemd) |

--- a/reading/testing_genservers.livemd
+++ b/reading/testing_genservers.livemd
@@ -239,6 +239,6 @@ $ git commit -m "finish testing genservers section"
 
 ## Up Next
 
-| Previous                                             | Next                               |
-| ---------------------------------------------------- | ---------------------------------: |
-| [Metaprogramming](../reading/metaprogramming.livemd) | [Stack](../exercises/stack.livemd) |
+| Previous                                             | Next                         |
+| ---------------------------------------------------- | ---------------------------: |
+| [Metaprogramming](../reading/metaprogramming.livemd) | [IEx](../reading/iex.livemd) |

--- a/reading/web_servers.livemd
+++ b/reading/web_servers.livemd
@@ -185,4 +185,4 @@ $ git commit -m "finish web servers section"
 
 | Previous                                       | Next                                 |
 | ---------------------------------------------- | -----------------------------------: |
-| [Pokemon Api](../exercises/pokemon_api.livemd) | [Phoenix](../reading/phoenix.livemd) |
+| [Pokemon API](../exercises/pokemon_api.livemd) | [Phoenix](../reading/phoenix.livemd) |

--- a/reading/with.livemd
+++ b/reading/with.livemd
@@ -292,7 +292,7 @@ Run the following in your command line from the beta_curriculum folder to track 
 
 ```
 $ git add .
-$ git commit -m "finish pattern matching section"
+$ git commit -m "finish with section"
 ```
 
 ## Up Next

--- a/utils/lib/mix/tasks/add_navigation.ex
+++ b/utils/lib/mix/tasks/add_navigation.ex
@@ -51,7 +51,35 @@ defmodule Mix.Tasks.Bc.AddNavigation do
     [name, _extension] = String.split(file_name, ".")
 
     String.split(name, "_")
-    |> Enum.map(&String.capitalize/1)
+    |> Enum.map(&capitalize/1)
     |> Enum.join(" ")
+  end
+
+  @custom_capitalizations %{
+    "api" => "API",
+    "apis" => "APIs",
+    "cli" => "CLI",
+    "css" => "CSS",
+    "datetime" => "DateTime",
+    "ets" => "ETS",
+    "exunit" => "ExUnit",
+    "fizzbuzz" => "FizzBuzz",
+    "genserver" => "GenServer",
+    "genservers" => "GenServers",
+    "html" => "HTML",
+    "iex" => "IEx",
+    "io" => "IO",
+    "liveview" => "LiveView",
+    "mapset" => "MapSet",
+    "mapsets" => "MapSets",
+    "rdbms" => "RDBMS",
+    "rpg" => "RPG",
+    "rps" => "RPS",
+    "saferange" => "SafeRange"
+  }
+
+  defp capitalize(word) do
+    @custom_capitalizations
+    |> Map.get(String.downcase(word), String.capitalize(word))
   end
 end


### PR DESCRIPTION
Fixes #487 

Introduces a custom `capitalize` method in the script that generates and adds the navigation links which takes into consideration a map of custom capitalizations, for example: `"exunit" => "ExUnit"`.

I populated the list with everything I noticed as I clicked through each page, but any additional customizations can be added after-the-fact as they arise.

The only code change was in `utils/lib/mix/tasks/add_navigation.ex` while the rest of the changes were  performed by `mix bc`.

![Screen Shot 2022-10-11 at 12 56 37 PM](https://user-images.githubusercontent.com/689382/195186509-bc2622be-9cf6-47a9-ada8-e82257d70af3.png)
