### PR TITLE
Update Email Validation exercise hint to reflect the function used in the example

### DIFF
--- a/exercises/email_validation.livemd
+++ b/exercises/email_validation.livemd
@@ -37,7 +37,7 @@ For the sake of this exercise, an email is valid if it is in the format `string@
 <details style="background-color: burlywood; padding: 1rem; margin: 1rem 0;">
 <summary>Hint</summary>
 
-Consider using [Regex.replace/4](https://hexdocs.pm/elixir/Regex.html#replace/4).
+Consider using [Regex.match/2](https://hexdocs.pm/elixir/Regex.html#match?/2).
 
 </details>
 

--- a/reading/documentation_and_static_analysis.livemd
+++ b/reading/documentation_and_static_analysis.livemd
@@ -408,4 +408,4 @@ $ git commit -m "finish documentation and static analysis section"
 
 | Previous                           | Next                               |
 | ---------------------------------- | ---------------------------------: |
-| [Exunit](../reading/exunit.livemd) | [Stack](../exercises/stack.livemd) |
+| [ExUnit](../reading/exunit.livemd) | [Stack](../exercises/stack.livemd) |

--- a/reading/iex.livemd
+++ b/reading/iex.livemd
@@ -295,4 +295,4 @@ $ git commit -m "finish iex section"
 
 | Previous                                                   | Next                         |
 | ---------------------------------------------------------- | ---------------------------: |
-| [Testing Genservers](../reading/testing_genservers.livemd) | [Mix](../reading/mix.livemd) |
+| [Testing GenServers](../reading/testing_genservers.livemd) | [Mix](../reading/mix.livemd) |

--- a/reading/metaprogramming.livemd
+++ b/reading/metaprogramming.livemd
@@ -509,4 +509,4 @@ $ git commit -m "finish metaprogramming section"
 
 | Previous                                       | Next                                                       |
 | ---------------------------------------------- | ---------------------------------------------------------: |
-| [Journal Cli](../exercises/journal_cli.livemd) | [Testing Genservers](../reading/testing_genservers.livemd) |
+| [Journal CLI](../exercises/journal_cli.livemd) | [Testing GenServers](../reading/testing_genservers.livemd) |

--- a/reading/testing_genservers.livemd
+++ b/reading/testing_genservers.livemd
@@ -241,4 +241,4 @@ $ git commit -m "finish testing genservers section"
 
 | Previous                                             | Next                         |
 | ---------------------------------------------------- | ---------------------------: |
-| [Metaprogramming](../reading/metaprogramming.livemd) | [Iex](../reading/iex.livemd) |
+| [Metaprogramming](../reading/metaprogramming.livemd) | [IEx](../reading/iex.livemd) |


### PR DESCRIPTION
Fixes #504 

Updates the suggested function and link in the hint for Email Validation to match up with the example solution.

The other changes here were changes from `mix bc`

![Screen Shot 2022-10-12 at 8 26 01 AM](https://user-images.githubusercontent.com/689382/195384439-7dd5eed4-73a1-438f-8bda-369648efc7ff.png)
