### PR TITLE
Remove palindrome example solution from the shell

### DIFF
--- a/exercises/palindrome.livemd
+++ b/exercises/palindrome.livemd
@@ -70,10 +70,6 @@ defmodule Palindrome do
     false
   """
   def palindrome?(string) do
-    string
-    |> String.split("")
-    |> Enum.reverse()
-    |> Enum.join() == string
   end
 end
 ```


### PR DESCRIPTION
Remove the given example solution in the palindrome exercise from the elixir shell.