### PR TITLE
add missing "]" to timeline examples

### DIFF
--- a/exercises/timeline.livemd
+++ b/exercises/timeline.livemd
@@ -103,7 +103,7 @@ defmodule Timeline do
 
   ## Examples
 
-    iex> Timeline.from_strings(["2020-01-01", "2020-01-02")
+    iex> Timeline.from_strings(["2020-01-01", "2020-01-02"])
     [1]
 
     iex> Timeline.from_strings(["2020-01-01", "2020-01-02", "2020-01-22"])


### PR DESCRIPTION
There is a missing ']' in the Timeline example code.

-    iex> Timeline.from_strings(["2020-01-01", "2020-01-02")
+    iex> Timeline.from_strings(["2020-01-01", "2020-01-02"])
