### PR TITLE
fix solution example for coordinates {0,0}

### DIFF
--- a/exercises/tic-tac-toe.livemd
+++ b/exercises/tic-tac-toe.livemd
@@ -132,7 +132,7 @@ defmodule TicTacToe do
 
     We've used a board with letter symbols for sake of example.
 
-    iex> board = [["A", "B", "C"], ["D", "E", "F"],["G", "H", "I"]]
+    iex> board = [["A", "B", "C"], ["D", "E", "F"], ["G", "H", "I"]]
     iex> TicTacToe.at(board, {0, 0})
     "G"
     iex> TicTacToe.at(board, {1, 0})
@@ -164,7 +164,7 @@ defmodule TicTacToe do
 
   iex> board = [[nil, nil, nil], [nil, nil, nil], [nil, nil, nil]]
   iex> TicTacToe.fill(board, {0, 0}, "X")
-  [[nil, nil, nil], [nil, nil, nil], [nil, nil, "X"]]
+  [[nil, nil, nil], [nil, nil, nil], ["X", nil, nil]]
   iex> TicTacToe.fill(board, {1, 1}, "O")
   [[nil, nil, nil], [nil, "O", nil], [nil, nil, nil]]
   iex> TicTacToe.fill(board, {2, 2}, "X")
@@ -172,7 +172,7 @@ defmodule TicTacToe do
 
   Filling an existing board
 
-  iex> TicTacToe.fill([[nil, "X", nil], [nil, "X", "O"],[nil, nil, "X"]], {2, 2}, "O")
+  iex> TicTacToe.fill([[nil, "X", nil], [nil, "X", "O"], [nil, nil, "X"]], {2, 2}, "O")
   [[nil, "X", "O"], [nil, "X", "O"],[nil, nil, "X"]]
   """
   def fill(board, coordinate, symbol) do


### PR DESCRIPTION
Fill example for coordinates {0, 0} seems inaccurate - according to graph at the top of the page position 'G' from the previous example:
```
iex> TicTacToe.fill(board, {0, 0}, "X")
-  [[nil, nil, nil], [nil, nil, nil], [nil, nil, "X"]]
+  [[nil, nil, nil], [nil, nil, nil], ["X", nil, nil]]
```

Also a few whitespace suggestions