### PR TITLE
Updated Example Solution in exercises/typespec_drills.livemd

### DIFF
--- a/exercises/typespec_drills.livemd
+++ b/exercises/typespec_drills.livemd
@@ -238,13 +238,13 @@ Implement the following custom `@type`s in the module below based on the comment
 ```elixir
 defmodule CustomTypes do
   # a string or number
-  @type unparsed_number :: string() | number()
+  @type unparsed_number :: String.t() | number()
   # a list of strings
-  @type strings :: [string()]
+  @type strings :: [String.t()]
   # a map with :title (string) and :content (string) keys. 
-  @type book :: %{title: string(), content: string()}
+  @type book :: %{title: String.t(), content: String.t()}
   # A map with :name (string) and `:books` (a list of books) keys.
-  @type author :: %{name: string(), books: [book()]}
+  @type author :: %{name: String.t(), books: [book()]}
 end
 ```
 


### PR DESCRIPTION
Changed Example Solution to use `String.t()` instead of `string()`