### PR TITLE
Correct Counter :decrement exercise

### DIFF
--- a/reading/processes.livemd
+++ b/reading/processes.livemd
@@ -346,7 +346,7 @@ defmodule Counter do
   end
 end
 
-counter_process = spawn(fn -> CounterProcess.loop() end)
+counter_process = spawn(fn -> Counter.loop() end)
 ```
 
 You should be able to send a `:decrement` message to a spawned `Counter`. Uncomment and evaluate the code below to test your solution.


### PR DESCRIPTION
Scaffolding invoked the incorrect module, which is unmodified to receive `:decrement`. 
 `CounterProcess` vs `Counter`