### PR TITLE
Update generic_server.livemd - Fix module name

### DIFF
--- a/reading/generic_server.livemd
+++ b/reading/generic_server.livemd
@@ -307,7 +307,7 @@ note_book = GenericServer.start(NoteBook)
 ```
 
 ```elixir
-defmodule Notebook do
+defmodule NoteBook do
 end
 ```
 


### PR DESCRIPTION
Updated your turn segment,;changed `Notebook` to `NoteBook`, matching module name in instructions and setup documentation.