### PR TITLE
added the correct pid variable name to example

### DIFF
--- a/reading/processes.livemd
+++ b/reading/processes.livemd
@@ -181,7 +181,7 @@ Or manually link a process with [Process.link/1](https://hexdocs.pm/elixir/Proce
 
 ```elixir
 pid1 = spawn(fn -> raise "oops" end)
-Process.link(pid)
+Process.link(pid1)
 "I will not run, because the above crashes"
 ```
 


### PR DESCRIPTION
The example had:
```
pid1 = ...
Process.link(pid)
```

Changed it to:
```
Process.link(pid1)
```