### PR TITLE
timer.livemd uncomment starter code

### DIFF
--- a/exercises/timer.livemd
+++ b/exercises/timer.livemd
@@ -74,37 +74,37 @@ end
 Implement the `Timer` module as documented below. You will also have to implement the necessary [GenServer](https://hexdocs.pm/elixir/GenServer.html) callback functions such as [GenServer.init/1](https://hexdocs.pm/elixir/GenServer.html#init/1), [GenServer.handle_info/2](https://hexdocs.pm/elixir/GenServer.html#handle_info/2), and [GenServer.handle_call/3](https://hexdocs.pm/elixir/GenServer.html#handle_call/3).
 
 ```elixir
-# defmodule Timer do
-#   @moduledoc """
-#   Documentation for `Timer`
-#   """
-#   use GenServer
+ defmodule Timer do
+   @moduledoc """
+   Documentation for `Timer`
+   """
+   use GenServer
 
-#   @doc """
-#   Start the `Timer` process.
+   @doc """
+   Start the `Timer` process.
 
-#   ## Examples
+   ## Examples
 
-#       iex> {:ok, pid} = Timer.start_link([])
-#   """
-#   def start_link(_opts) do
-#   end
+       iex> {:ok, pid} = Timer.start_link([])
+   """
+   def start_link(_opts) do
+   end
 
-#   @doc """
-#   Get the number of seconds that have elapsed since the `Timer` was started.
+   @doc """
+   Get the number of seconds that have elapsed since the `Timer` was started.
 
-#   ## Examples
+   ## Examples
 
-#     iex> {:ok, pid} = Timer.start_link([])
-#     iex> Timer.seconds(pid)
-#     0
-#     iex> Process.sleep(1200)
-#     iex> Timer.seconds(pid)
-#     1
-#   """
-#   def seconds(timer_pid) do
-#   end
-# end
+     iex> {:ok, pid} = Timer.start_link([])
+     iex> Timer.seconds(pid)
+     0
+     iex> Process.sleep(1200)
+     iex> Timer.seconds(pid)
+     1
+   """
+   def seconds(timer_pid) do
+   end
+ end
 ```
 
 ## Bonus :timer


### PR DESCRIPTION
Starter code for the exercise was all commented out.