### PR TITLE
changed body on http request

### DIFF
--- a/reading/apis.livemd
+++ b/reading/apis.livemd
@@ -180,7 +180,7 @@ Below we send a POST request to http://httparrot.herokuapp.com/post. The body is
 `Content-Type` header specifies that the data being sent is JSON.
 
 ```elixir
-HTTPoison.post("http://httparrot.herokuapp.com/post", Poison.encode!(%{body: "value"}), [
+HTTPoison.post("http://httparrot.herokuapp.com/post", Poison.encode!(%{body: "test"}), [
   {"Content-Type", "application/json"}
 ])
 ```


### PR DESCRIPTION
Hi @BrooklinJazz  =)

On the HTTP request, the value in the body key was "value" and not "test," as mentioned in the paragraph above, causing an error. I don't know if it was on purpose so that the students could change it for themselves, but since I haven't seen any clear command to do so, I decided to send this PR =)

