### PR TITLE
correction, punctuation in reading/livebook > evaluation section

### DIFF
--- a/reading/livebook.livemd
+++ b/reading/livebook.livemd
@@ -124,11 +124,11 @@ Evaluate the first cell and notice that the cell below becomes **Stale**.
 
 This means that if the second cell relies on any value in the first cell, it is now outdated.
 
-If you change a cell, **Evaluated** changes to *Evaluated* to indicate that the cell has changed
-since the last time, it was evaluated.
+If you change a cell, **Evaluated** changes to *Evaluated\** to indicate that the cell has changed
+since the last time it was evaluated.
 
-Evaluate the Elixir cell below, then change `5` to `4` to see **Evaluated** change to *Evaluated*.
-Re-evaluate the cell to see *Evaluated* change to **Evaluated**.
+Evaluate the Elixir cell below, then change `5` to `4` to see **Evaluated** change to *Evaluated\**.
+Re-evaluate the cell to see *Evaluated\** change to **Evaluated**.
 
 ```elixir
 5


### PR DESCRIPTION
- when Evaluated becomes italicized to indicate that a cell has changed since last evaluated, it is also followed by an asterisk
- unnecessary comma