### PR TITLE
Fix Off-by-one error in Caesar Cypher

### DIFF
--- a/exercises/caesar_cypher.livemd
+++ b/exercises/caesar_cypher.livemd
@@ -60,7 +60,7 @@ defmodule CaesarCypher do
     |> Enum.map(fn char ->
       overflow = char + key > ?z
       if overflow do
-        rem(char + key, ?z) + ?a
+        ?a + rem(char + key, ?z) - 1
       else
         char + key
       end


### PR DESCRIPTION
The Example Solution in Caesar Cypher exercise has an off-by-one error in `CaesarCyphe.encode/2` while shifting from 'z' to 'a'. 

**Current function definition**

![image](https://user-images.githubusercontent.com/30313228/205021553-51672050-02c0-418e-9dc4-1001ae74efbd.png)

**Resulting in**
```shell
iex(1)> CaesarCyphe.encode("z", 1)
"b"
iex(2)> CaesarCyphe.encode("z", 2)
"c"
```



