### PR TITLE
Fix example solution in time converting excersice

### DIFF
--- a/exercises/time_converting.livemd
+++ b/exercises/time_converting.livemd
@@ -35,7 +35,7 @@ defmodule TimeConverter do
 
   def from_seconds(amount, unit) do
     case unit do
-      :seconds -> amount
+      :seconds -> amount * 1.0
       :minutes -> amount / 60
       :hours -> amount / 60 / 60
       :days -> amount / 60 / 60 / 24


### PR DESCRIPTION
- As per the doc tests the returning unit of time should be in float.