### PR TITLE
Remove trailing space and fix doc tests in math_with_guards

### DIFF
--- a/exercises/math_with_guards.livemd
+++ b/exercises/math_with_guards.livemd
@@ -110,16 +110,16 @@ defmodule Math do
     "123456"
 
     iex> Math.add(1.0, 2.0)
-    ** (FunctionClauseError) no function clause matching in Math.add/2 
+    ** (FunctionClauseError) no function clause matching in Math.add/2
 
     iex> Math.add(2, "2")
-    ** (FunctionClauseError) no function clause matching in Math.add/2 
+    ** (FunctionClauseError) no function clause matching in Math.add/2
 
     iex> Math.add({}, {})
-    ** (FunctionClauseError) no function clause matching in Math.add/2 
+    ** (FunctionClauseError) no function clause matching in Math.add/2
 
     iex> Math.add(%{}, %{})
-    ** (FunctionClauseError) no function clause matching in Math.add/2 
+    ** (FunctionClauseError) no function clause matching in Math.add/2
   """
   def add(value1, value2) do
   end
@@ -149,16 +149,16 @@ defmodule Math do
     "bc"
 
     iex> Math.subtract(1.0, 2.0)
-    ** (FunctionClauseError) no function clause matching in Math.subtract/2 
+    ** (FunctionClauseError) no function clause matching in Math.subtract/2
 
     iex> Math.subtract(2, "2")
-    ** (FunctionClauseError) no function clause matching in Math.subtract/2 
+    ** (FunctionClauseError) no function clause matching in Math.subtract/2
 
     iex> Math.subtract({}, {})
-    ** (FunctionClauseError) no function clause matching in Math.subtract/2 
+    ** (FunctionClauseError) no function clause matching in Math.subtract/2
 
     iex> Math.subtract(%{}, %{})
-    ** (FunctionClauseError) no function clause matching in Math.subtract/2 
+    ** (FunctionClauseError) no function clause matching in Math.subtract/2
   """
   def subtract(value1, value2) do
   end


### PR DESCRIPTION
- The doc tests for `FunctionClauseError` fails since the exception message contains trailing space.