### PR TITLE
Fix decimal-hexdecimal table values

### DIFF
--- a/reading/strings_and_binaries.livemd
+++ b/reading/strings_and_binaries.livemd
@@ -231,7 +231,7 @@ sixteen symbols (0-9 a-f).
 
 Hexadecimal uses decimal symbols from `1` to `9`. Then switches to using the letters `a` to `f` as you can see in the following table.
 
-<!-- livebook:{"attrs":{"source":"\"0,1,2,3,4,5,6,7,8,9,10,a,b,c,d,e,f\"\n|> String.split(\",\")\n|> Enum.with_index()\n|> Enum.map(fn {symbol, index} -> %{integer: \"#{index}\", hexadecimal: symbol} end)\n|> Enum.take(-10)\n|> Kino.DataTable.new()","title":"Hexadecimal"},"kind":"Elixir.HiddenCell","livebook_object":"smart_cell"} -->
+<!-- livebook:{"attrs":{"source":"\"0,1,2,3,4,5,6,7,8,9,a,b,c,d,e,f\"\n|> String.split(\",\")\n|> Enum.with_index()\n|> Enum.map(fn {symbol, index} -> %{integer: \"#{index}\", hexadecimal: symbol} end)\n|> Enum.take(-10)\n|> Kino.DataTable.new()","title":"Hexadecimal"},"kind":"Elixir.HiddenCell","livebook_object":"smart_cell"} -->
 
 ```elixir
 "0,1,2,3,4,5,6,7,8,9,10,a,b,c,d,e,f"


### PR DESCRIPTION
- Decimal `10` maps to `a` in hexadecimal but in the table it maps to `10` in hexadecimal.

**Before**
![image](https://user-images.githubusercontent.com/9105503/210395527-48fe585b-349c-4326-adc7-d1b63c1962c0.png)

**After**
![image](https://user-images.githubusercontent.com/9105503/210395645-75d6fb15-20e2-40b0-b16f-ec3e192f6951.png)
