### PR TITLE
fix commented elixir syntax

### DIFF
--- a/reading/supervisors.livemd
+++ b/reading/supervisors.livemd
@@ -72,7 +72,7 @@ Process.sleep(100)
 When a linked process crashes, it will also crashed the process that spawned it. Uncomment the code below, and you'll see it crashes the current Livebook process. Re-comment the code when finished.
 
 ```elixir
-# spawn_link(fn -> Raise "error" End)
+# spawn_link(fn -> raise "error" end)
 ```
 
 That means if we start a [GenServer](https://hexdocs.pm/elixir/GenServer.html) (or other process) **unsupervised** it will raise an error if it crashes.


### PR DESCRIPTION
get this error when uncommented

```
** (MismatchedDelimiterError) mismatched delimiter found on Library/Application Support/livebook/autosaved/2024_12_08/16_00_eywx/supervisors.livemd#cell:lw3q5x36ac2vp7tg:1:35:
    error: unexpected token: )
    │
  1 │ spawn_link(fn -> Raise "error" End)
    │            │                      └ mismatched closing delimiter (expected "end")
    │            └ unclosed delimiter
    │
    └─ Library/Application Support/livebook/autosaved/2024_12_08/16_00_eywx/supervisors.livemd#cell:lw3q5x36ac2vp7tg:1:35

```
